### PR TITLE
bridge2: show session list with dates instead of ids

### DIFF
--- a/images/bridge2/tracks/tracks.go
+++ b/images/bridge2/tracks/tracks.go
@@ -31,8 +31,12 @@ type Handler interface {
 	HandleEvent(Event)
 }
 
+func newIDWithTime(t time.Time) ID {
+	return ID(xid.NewWithTime(t).String())
+}
+
 func newID() ID {
-	return ID(xid.New().String())
+	return newIDWithTime(time.Now().UTC())
 }
 
 type EventMeta struct {
@@ -77,6 +81,22 @@ func (e *Event) UnmarshalCBOR(data []byte) error {
 	return nil
 }
 
+type SessionInfo struct {
+	ID    ID
+	Start time.Time
+}
+
+func LoadSessionInfo(root, id string) (*SessionInfo, error) {
+	x, err := xid.FromString(id)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionInfo{
+		ID:    ID(id),
+		Start: x.Time(),
+	}, nil
+}
+
 type Session struct {
 	EventEmitter
 	ID     ID
@@ -85,9 +105,10 @@ type Session struct {
 }
 
 func NewSession() *Session {
+	start := time.Now().UTC()
 	return &Session{
-		ID:    newID(),
-		Start: time.Now().UTC(),
+		ID:    newIDWithTime(start),
+		Start: start,
 	}
 }
 

--- a/images/bridge2/tracks/tracks.go
+++ b/images/bridge2/tracks/tracks.go
@@ -124,8 +124,9 @@ type sessionSnapshot struct {
 
 func (s *Session) snapshot() *sessionSnapshot {
 	snap := &sessionSnapshot{
-		ID:    s.ID,
-		Start: s.Start,
+		ID:     s.ID,
+		Start:  s.Start,
+		Tracks: []*trackSnapshot{}, // empty slice to ensure it doesn't serialize as "null"
 	}
 	s.tracks.Range(func(key, value any) bool {
 		snap.Tracks = append(snap.Tracks, value.(*Track).snapshot())
@@ -297,6 +298,7 @@ func (t *Track) snapshot() *trackSnapshot {
 		ID:     t.ID,
 		Start:  t.start,
 		Format: t.audio.Format(),
+		Events: []Event{}, // empty slice to ensure it doesn't serialize as "null"
 	}
 	t.rangeEvents(func(e Event) bool {
 		data.Events = append(data.Events, e)

--- a/images/bridge2/ui/sidebar.js
+++ b/images/bridge2/ui/sidebar.js
@@ -21,8 +21,8 @@ export var Sidebar = {
           ]
         ),
         ...sessions.map(s => m("div", {"class":"px-6 py-2"}, 
-          m("a", {"href":`./sessions/${s}`}, 
-            s
+          m("a", {"href":`./sessions/${s.ID}`},
+            new Date(s.Start).toLocaleString()
           )
         )) 
       ]


### PR DESCRIPTION
Instead of just listing the sessions by id, open the session files to get the start time as well. Depending on speed, some caching might be helpful here, or a file watcher to only load on-demand.

Fixes #48