### PR TITLE
bridge2: read config from the environment

### DIFF
--- a/defs/bridge2.cue
+++ b/defs/bridge2.cue
@@ -13,5 +13,8 @@ lenses: "bridge2": {
         { source: "\(#var.host_source_directory)/images/bridge2/ui", destination: "/go/src/github.com/ajbouh/substrate/images/bridge2/ui", mode: "ro" },
       }
     ]
+    environment: {
+      BRIDGE_URL_BASE_PATH: "/gw/bridge2",
+    }
   }
 }


### PR DESCRIPTION
Uses `BRIDGE_URL_BASE_PATH` set in Cue to configure
the URL prefix, and parses the `PORT` environment
variable.

Fixes #101
