### PR TITLE
bridge2: only require microphone permissions

### DIFF
--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -36,15 +36,16 @@ const initSession = () => {
   };
 };
 
-const localMedia = new LocalMedia();
-localMedia.videoEnabled = false;
-localMedia.ondevicechange = () => m.redraw();
-localMedia.onstreamchange = (stream) => {
+const localMedia = new LocalMedia({
+  videoEnabled: false,
+  ondevicechange: () => m.redraw(),
+  onstreamchange: (stream) => {
     if (sess == null) {
       initSession();
     }
     sess.setStream(stream);
-}
+  },
+});
 
 let viewModel = {};
 let dataWS = new WebSocket(`${webSocketURL}?data`);

--- a/images/bridge2/webrtc/js/localmedia.js
+++ b/images/bridge2/webrtc/js/localmedia.js
@@ -1,15 +1,24 @@
 class LocalMedia {
-  constructor() {
-    this.onstreamchange = (stream) => null;
-    this.ondevicechange = () => null;
-    this.audioDevices = [];
-    this.videoDevices = [];
-    this.outputDevices = [];
-    this.audioSource = undefined;
-    this.videoSource = undefined;
-    this.audioEnabled = true;
-    this.videoEnabled = true;
-    this.stream = undefined;
+  constructor(opts) {
+    let defaults = {
+      onstreamchange: (stream) => null,
+      ondevicechange: () => null,
+      audioDevices: [],
+      videoDevices: [],
+      outputDevices: [],
+      audioSource: undefined,
+      videoSource: undefined,
+      audioEnabled: true,
+      videoEnabled: true,
+      stream: undefined,
+    };
+    for (const [key, defaultValue] of Object.entries(defaults)) {
+      if (opts.hasOwnProperty(key)) {
+        this[key] = opts[key];
+      } else {
+        this[key] = defaultValue;
+      }
+    }
     this.updateStream();
     this.updateDevices();
     navigator.mediaDevices.addEventListener('devicechange', () => this.updateDevices());
@@ -49,8 +58,8 @@ class LocalMedia {
       });
     } else {
       this.stream = await navigator.mediaDevices.getUserMedia({
-        audio: {deviceId: this.audioSource ? {exact: this.audioSource} : true},
-        video: {deviceId: this.videoSource ? {exact: this.videoSource} : true}
+        audio: this.audioEnabled ? {deviceId: this.audioSource ? {exact: this.audioSource} : true} : false,
+        video: this.videoEnabled ? {deviceId: this.videoSource ? {exact: this.videoSource} : true} : false,
       });
     }
     if (!this.audioEnabled) {


### PR DESCRIPTION
The bridge code was setting `videoEnabled = false`
but in `LocalMedia` we need to:

1) use the video/audio enabled to only request the
   specified devices

2) pass in initial values for properties so that
   they're taken into account on the first call to
   `updateDevices()`

Fixes #107
