### PR TITLE
bridge2: send mic and tab audio simultaneously

### DIFF
--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -25,27 +25,48 @@ let webSocketURL = (() => {
   return u.toString();
 })();
 
-let sess = null;
+let micSess = null;
+let screenSess = null;
 const initSession = () => {
-  sess = new SFU(`${webSocketURL}?sfu`);
+  let sess = new SFU(`${webSocketURL}?sfu`);
   sess.onclose = (evt) => console.log("Websocket has closed");
   sess.onerror = (evt) => console.log("ERROR: " + evt.data);
   sess.ontrack = ({ streams: [stream], track }) => {
     // no-op!
     return
   };
+  return sess;
 };
 
 const localMedia = new LocalMedia({
   videoSource: false,
   ondevicechange: () => m.redraw(),
   onstreamchange: (stream) => {
-    if (sess == null) {
-      initSession();
+    if (micSess == null) {
+      micSess = initSession();
     }
-    sess.setStream(stream);
+    micSess.setStream(stream);
   },
 });
+
+let screenMedia = null;
+
+const shareScreen = () => {
+  if (screenMedia) {
+    screenMedia.updateStream();
+    return
+  }
+  screenMedia = new LocalMedia({
+    videoSource: 'screen',
+    // videoEnabled: false,
+    onstreamchange: (stream) => {
+      if (screenSess == null) {
+        screenSess = initSession();
+      }
+      screenSess.setStream(stream);
+    },
+  });
+};
 
 let viewModel = {};
 let dataWS = new WebSocket(`${webSocketURL}?data`);
@@ -73,7 +94,7 @@ m.mount(document.body, {
     m(Sidebar, {sessions: viewModel.sessions}),
     m("div", {"class":"flex flex-col mx-auto grow"},
       [
-        m(Topbar, {localMedia}),
+        m(Topbar, {localMedia, shareScreen}),
         m("div", {"class":"grow px-6 mt-4 overflow-auto","id":"session"},
           m(Session, {summary: "Summary", entries: viewModel.entries})
         )

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -37,7 +37,7 @@ const initSession = () => {
 };
 
 const localMedia = new LocalMedia({
-  videoEnabled: false,
+  videoSource: false,
   ondevicechange: () => m.redraw(),
   onstreamchange: (stream) => {
     if (sess == null) {

--- a/images/bridge2/ui/topbar.js
+++ b/images/bridge2/ui/topbar.js
@@ -32,7 +32,7 @@ export var Topbar = {
           m("button", {
             class:"p-2 border border-gray-600 rounded-md text-md focus:border-blue-500 focus:ring-blue-500 bg-gray-700 text-gray-400",
             disabled: false,
-            onclick: () => localMedia.shareScreen()
+            onclick: () => attrs.shareScreen()
           },
             "Send System Audio"
           )

--- a/images/bridge2/vad/vad.go
+++ b/images/bridge2/vad/vad.go
@@ -80,6 +80,11 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 	}
 	win := a.Window(string(annot.Track().ID))
 	start, ok := win.Push(pcm, annot.End)
+	// the VAD window is subtracting a 500ms buffer before audio is detected, but
+	// clamp that to the start of the track
+	if start < annot.Track().Start() {
+		start = annot.Track().Start()
+	}
 	if ok && start != 0 {
 		annot.Track().Span(start, annot.End).RecordEvent("activity", nil)
 	}

--- a/images/bridge2/webrtc/js/localmedia.js
+++ b/images/bridge2/webrtc/js/localmedia.js
@@ -46,7 +46,6 @@ class LocalMedia {
 
   shareScreen() {
     this.setVideoSource('screen');
-    this.updateStream();
   }
 
   async updateStream() {

--- a/images/bridge2/webrtc/js/localmedia.js
+++ b/images/bridge2/webrtc/js/localmedia.js
@@ -57,16 +57,26 @@ class LocalMedia {
         systemAudio: 'include',
       });
     } else {
+      const source = (src) => {
+        if (src === false) {
+          return false;
+        }
+        return {deviceId: src ? {exact: src} : true};
+      }
       this.stream = await navigator.mediaDevices.getUserMedia({
-        audio: this.audioEnabled ? {deviceId: this.audioSource ? {exact: this.audioSource} : true} : false,
-        video: this.videoEnabled ? {deviceId: this.videoSource ? {exact: this.videoSource} : true} : false,
+        audio: source(this.audioSource),
+        video: source(this.videoSource),
       });
     }
     if (!this.audioEnabled) {
-      this.stream.getAudioTracks()[0].enabled = false;
+      for (const track of this.stream.getAudioTracks()) {
+        track.enabled = false;
+      }
     }
     if (!this.videoEnabled) {
-      this.stream.getVideoTracks()[0].enabled = false;
+      for (const track of this.stream.getVideoTracks()) {
+        track.enabled = false;
+      }
     }
     if (this.onstreamchange) {
       this.onstreamchange(this.stream);

--- a/images/bridge2/webrtc/js/session.js
+++ b/images/bridge2/webrtc/js/session.js
@@ -39,25 +39,23 @@ export class Session {
     }
   }
 
-  setStream(stream) {
-    const videoTrack = stream.getVideoTracks()[0];
-    const audioTrack = stream.getAudioTracks()[0];
-
-    const videoSender = this.peer.getSenders().find((s) => s.track && s.track.kind == videoTrack.kind);
-    const audioSender = this.peer.getSenders().find((s) => s.track && s.track.kind == audioTrack.kind);
-
-    if (videoSender) {
-      // console.log("replacing video track:", videoTrack.id);
-      videoSender.replaceTrack(videoTrack);
+  setTrack(track, stream) {
+    const sender = this.peer.getSenders().find((s) => s.track && s.track.kind == track.kind);
+    if (sender) {
+      sender.replaceTrack(track);
     } else {
-      // console.log("adding video track:", videoTrack.id);
-      this.peer.addTrack(videoTrack, stream);
+      this.peer.addTrack(track, stream);
     }
+  }
 
-    if (audioSender) {
-      audioSender.replaceTrack(audioTrack);
-    } else {
-      this.peer.addTrack(audioTrack, stream);
+  setStream(stream) {
+    for (const track of stream.getVideoTracks()) {
+      this.setTrack(track, stream);
+      break; // send at most one video track
+    }
+    for (const track of stream.getAudioTracks()) {
+      this.setTrack(track, stream);
+      break; // send at most one audio track
     }
   }
 


### PR DESCRIPTION
When sending the tab audio, create a new session to allow sending at the same
time as the mic track. Ideally we can send multiple audio tracks in the same
session, but it requires some API changes, so for now start a second session.

Fixes #117

Also removes a duplicate call to open the screen media picker (Fixes #108)

And fixes a bug where the timestamps for voice activity events could be earlier
than the track start time. The computed negative timestamp led to a crash when
trying to slice the audio buffer.
