### PR TITLE
bridge2: only redirect requests for `/`

### DIFF
--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -352,7 +352,13 @@ func (m *Main) Serve(ctx context.Context) {
 
 	http.Handle("/webrtc/", http.StripPrefix("/webrtc", http.FileServer(http.FS(js.Dir))))
 	http.Handle("/ui/", http.StripPrefix("/ui", http.FileServer(http.FS(ui.Dir))))
-	http.Handle("/", http.RedirectHandler(path.Join(m.basePath, "sessions"), http.StatusFound))
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, path.Join(m.basePath, "sessions"), http.StatusFound)
+	})
 
 	log.Printf("running on http://localhost:%d ...", m.port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", m.port), nil))


### PR DESCRIPTION
The http ServeMux pattern `/` any requests that
aren't already assigned, so this would redirect
other unknown paths to `/sessions` and create a
new session. So on page loads, extra requests
like `/favicon.ico` would trigger a new session
in the background.

This only redirects when the path is just `/`.

Additionally we could have the `GET /session`
index not create a session, and leave that to a JS
POST call on load, but refining the redirect is
good enough for the moment.

Fixes #123
