### PR TITLE
bridge2: load past sessions from disk

### DIFF
--- a/images/bridge2/tracks/tracks.go
+++ b/images/bridge2/tracks/tracks.go
@@ -2,6 +2,8 @@ package tracks
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"sync"
@@ -94,6 +96,19 @@ func LoadSessionInfo(root, id string) (*SessionInfo, error) {
 		ID:    ID(id),
 		Start: x.Time(),
 	}, nil
+}
+
+func LoadSession(root, id string) (*Session, error) {
+	var s Session
+	f, err := os.Open(filepath.Join(root, id, "session"))
+	if err != nil {
+		return nil, err
+	}
+	if err := cbor.NewDecoder(f).Decode(&s); err != nil {
+		return nil, err
+	}
+	// FIXME load the audio tracks as well
+	return &s, nil
 }
 
 type Session struct {

--- a/images/bridge2/tracks/tracks.go
+++ b/images/bridge2/tracks/tracks.go
@@ -24,7 +24,6 @@ type Span interface {
 	Audio() beep.Streamer
 	EventTypes() []string
 	Events(typ string) []Event
-	RecordEvent(typ string, data any) Event
 }
 
 type Handler interface {
@@ -187,10 +186,6 @@ type Track struct {
 }
 
 var _ Span = (*Track)(nil)
-
-func (t *Track) RecordEvent(typ string, data any) Event {
-	return t.record(typ, t, data)
-}
 
 func (t *Track) record(typ string, span Span, data any) Event {
 	e := Event{
@@ -358,10 +353,6 @@ type filteredSpan struct {
 
 var _ Span = (*filteredSpan)(nil)
 
-func (s *filteredSpan) RecordEvent(typ string, data any) Event {
-	return s.Track().record(typ, s, data)
-}
-
 func (s *filteredSpan) EventTypes() []string {
 	// TODO should it return all types for the Track, or only ones found within this span?
 	return s.Track().EventTypes()
@@ -408,7 +399,17 @@ func (s *filteredSpan) Track() *Track {
 
 var eventTypes = map[string]reflect.Type{}
 
-func RegisterEvent[T any](name string) {
+func EventRecorder[T any](name string) func(Span, T) Event {
 	// TODO(Go 1.22) can use reflect.TypeFor[T]()
 	eventTypes[name] = reflect.TypeOf((*T)(nil)).Elem()
+	return func(s Span, data T) Event {
+		return s.Track().record(name, s, data)
+	}
+}
+
+func NilEventRecorder(name string) func(Span) Event {
+	record := EventRecorder[*struct{}](name)
+	return func(s Span) Event {
+		return record(s, nil)
+	}
 }

--- a/images/bridge2/transcribe/transcribe.go
+++ b/images/bridge2/transcribe/transcribe.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ajbouh/substrate/images/bridge2/tracks"
 )
 
+var recordTranscription = tracks.EventRecorder[*Transcription]("transcription")
+
 type Agent struct {
 	Endpoint string
 }
@@ -42,7 +44,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 		return
 	}
 
-	annot.Span().RecordEvent("transcription", transcription)
+	recordTranscription(annot.Span(), transcription)
 }
 
 func (a *Agent) Transcribe(request *Request) (*Transcription, error) {

--- a/images/bridge2/vad/vad.go
+++ b/images/bridge2/vad/vad.go
@@ -69,6 +69,8 @@ func New(config Config) *Agent {
 	}
 }
 
+var recordActivity = tracks.NilEventRecorder("activity")
+
 func (a *Agent) HandleEvent(annot tracks.Event) {
 	if annot.Type != "audio" {
 		return
@@ -86,7 +88,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 		start = annot.Track().Start()
 	}
 	if ok && start != 0 {
-		annot.Track().Span(start, annot.End).RecordEvent("activity", nil)
+		recordActivity(annot.Track().Span(start, annot.End))
 	}
 }
 


### PR DESCRIPTION
We have been saving the sessions, but not loading
them when a new bridge process is started. This
enables reading past sessions from disk and
bringing them back into memory.

Right now old sessions are resumed by default, so
they'll start recording new audio automatically.
We may want to change that to archive them at a
certain point if they haven't been active so that
just looking up an old session doesn't
automatically modify it. However, we could give
the option to resume recording on that session.

Fixes #111
