### PR TITLE
bridge2: display timestamps correctly

### DIFF
--- a/images/bridge2/tracks/tracks.go
+++ b/images/bridge2/tracks/tracks.go
@@ -12,6 +12,19 @@ import (
 	"github.com/rs/xid"
 )
 
+var cborenc = func() cbor.EncMode {
+	// We have to repeat this here since cbor doesn't have a way to propagate
+	// these options down. So since we customize the encoding, calling
+	// cbor.Marshal() would lose the options set in the main package.
+	opts := cbor.CoreDetEncOptions()
+	opts.Time = cbor.TimeRFC3339
+	em, err := opts.EncMode()
+	if err != nil {
+		panic(err)
+	}
+	return em
+}()
+
 type Timestamp time.Duration // relative to stream start
 type ID string
 
@@ -160,7 +173,7 @@ func (s *Session) snapshot() *sessionSnapshot {
 }
 
 func (s *Session) MarshalCBOR() ([]byte, error) {
-	return cbor.Marshal(s.snapshot())
+	return cborenc.Marshal(s.snapshot())
 }
 
 func (s *Session) UnmarshalCBOR(data []byte) error {

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -75,16 +75,17 @@ dataWS.onmessage = e => {
   const data = CBOR.decode((new Uint8Array(e.data)).buffer);
 
   const events = data.Session.Tracks.map(t => t.Events).filter(e => e).flat();
+  const sessionStart = new Date(data.Session.Start).getTime();
 
   viewModel = {
     sessions: data.Sessions,
     entries: events.filter(e => e.Type === "transcription").map(t => {
       return {
         speakerLabel: "user",
-        time: t.Start, // todo: convert
+        start: new Date(sessionStart + (t.Start / 1000000)), // todo: convert
         text: t.Data.segments.map(s => s.text).join()
       }
-    })
+    }).sort(({start}) => start)
   }
   m.redraw()
 }

--- a/images/bridge2/ui/session.js
+++ b/images/bridge2/ui/session.js
@@ -22,8 +22,8 @@ export var Entry = {
     return m("div", {"class":"entry"}, [
       m("div", {"class":"left"},
         [
-          m("div", {"class":"time"}, formatTime(attrs.time)),
-          m("div", {"class":"session-time"}, formatSessionTime(attrs.sessionTime))
+          m("div", {"class":"time"}, formatTime(attrs.start)),
+          // m("div", {"class":"session-time"}, formatSessionTime(attrs.sessionTime))
         ]
       ),
       m("div", {"class":"line","style":{"background-color":attrs.lineColor}},


### PR DESCRIPTION
Convert event time offsets to a JS Date for
display.

Sorts all events by time so that events from
multiple tracks are merged in-order.

Fixes #122
