### PR TITLE
bridge2: clamp VAD start after checking for 0

### DIFF
--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -78,7 +78,7 @@ func (l eventLogger) HandleEvent(e tracks.Event) {
 			return
 		}
 	}
-	log.Printf("event: %s %s %s", e.Type, e.ID, time.Duration(e.Start))
+	log.Printf("event: %s %s %s-%s", e.Type, e.ID, time.Duration(e.Start), time.Duration(e.End))
 }
 
 type Main struct {

--- a/images/bridge2/vad/vad.go
+++ b/images/bridge2/vad/vad.go
@@ -82,12 +82,13 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 	}
 	win := a.Window(string(annot.Track().ID))
 	start, ok := win.Push(pcm, annot.End)
-	// the VAD window is subtracting a 500ms buffer before audio is detected, but
-	// clamp that to the start of the track
-	if start < annot.Track().Start() {
-		start = annot.Track().Start()
-	}
 	if ok && start != 0 {
+		// the VAD window is subtracting a 500ms buffer before audio is detected, but
+		// clamp that to the start of the track
+		if start < annot.Track().Start() {
+			log.Printf("vad: clamping start %d to track start %d", start, annot.Track().Start())
+			start = annot.Track().Start()
+		}
 		recordActivity(annot.Track().Span(start, annot.End))
 	}
 }


### PR DESCRIPTION
Clamping the VAD start time to the beginning of
the track should happen only when it has detected
activity. This was emitting extra "activity"
events when there wasn't a valid start time,
leading to duplicated transcription from the
beginning of the track.

Fixes #135
