### PR TITLE
fix: give up when a container crashes on boot

### DIFF
--- a/images/substrate/provisioner/docker/status.go
+++ b/images/substrate/provisioner/docker/status.go
@@ -107,6 +107,9 @@ func (c *ContainerStatusCheck) waitUntilReadyTCP(ctx context.Context, maxAttempt
 			log.Printf("waitUntilReadyTCP try host=%s port=%s attempts=%d maxAttempts=%d", c.host, c.port, attempts, maxAttempts)
 			conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", c.host, c.port))
 			if err != nil {
+				if e, ok := err.(*net.DNSError); ok && e.IsNotFound {
+					return fmt.Errorf("gave up waiting for the container to be ready, since it seems to be gone: %w", err)
+				}
 				attempts++
 				log.Printf("waitUntilReadyTCP err host=%s port=%s attempts=%d maxAttempts=%d err=%s", c.host, c.port, attempts, maxAttempts, err)
 				continue

--- a/images/substrate/provisioner/podman/status.go
+++ b/images/substrate/provisioner/podman/status.go
@@ -107,6 +107,9 @@ func (c *ContainerStatusCheck) waitUntilReadyTCP(ctx context.Context, maxAttempt
 			log.Printf("waitUntilReadyTCP try host=%s port=%s attempts=%d maxAttempts=%d", c.host, c.port, attempts, maxAttempts)
 			conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", c.host, c.port))
 			if err != nil {
+				if e, ok := err.(*net.DNSError); ok && e.IsNotFound {
+					return fmt.Errorf("gave up waiting for the container to be ready, since it seems to be gone: %w", err)
+				}
 				attempts++
 				log.Printf("waitUntilReadyTCP err host=%s port=%s attempts=%d maxAttempts=%d err=%s", c.host, c.port, attempts, maxAttempts, err)
 				continue


### PR DESCRIPTION
When a container crashes on boot we see the error: "dial tcp: lookup xxx.xxx.xxx.xxx: no such host". Detect this type of error and give up waiting for it.