### PR TITLE
dev: add run translator and transcribe tests to bb

### DIFF
--- a/defs/bb.cue
+++ b/defs/bb.cue
@@ -2,6 +2,22 @@ package defs
 
 enable: "bb": true
 
+tests: "bb": transcribe: {
+  test_templates["transcriber"]
+
+  environment: URL: "http://substrate:8080/bb/"
+  depends_on: "bb": true
+  depends_on: "substrate": true
+}
+
+tests: "bb": translate: {
+  test_templates["translator"]
+
+  environment: URL: "http://substrate:8080/bb/"
+  depends_on: "bb": true
+  depends_on: "substrate": true
+}
+
 tests: "bb": go: {
   build: {
     target: "test"

--- a/defs/defs.cue
+++ b/defs/defs.cue
@@ -282,6 +282,10 @@ for key, def in #out.resourcedir_fetches {
         if suitedef.depends_on != _|_ {
           depends_on: [ for dep, b in suitedef.depends_on { dep } ]
         }
+        networks: [
+          #var.substrate.internal_network_name,
+          #var.substrate.external_network_name,
+        ]
       }
     }
   }

--- a/defs/faster-whisper.cue
+++ b/defs/faster-whisper.cue
@@ -10,7 +10,7 @@ tests: "faster-whisper": transcribe: {
   test_templates["transcriber"]
 
   environment: URL: "http://substrate:8080/faster-whisper/v1/transcribe"
-  depends_on: "faster-whisper": true
+  depends_on: "substrate": true
 }
 
 // default model choices are

--- a/defs/seamlessm4t.cue
+++ b/defs/seamlessm4t.cue
@@ -11,14 +11,14 @@ live_edit: "seamlessm4t": bool
 tests: "seamlessm4t": translate: {
   test_templates["translator"]
 
-  environment: URL: "http://host.docker.internal:8080/seamlessm4t/v1/transcribe"
+  environment: URL: "http://substrate:8080/seamlessm4t/v1/transcribe"
   depends_on: "substrate": true
 }
 
 tests: "seamlessm4t": transcribe: {
   test_templates["transcriber"]
 
-  environment: URL: "http://host.docker.internal:8080/seamlessm4t/v1/transcribe"
+  environment: URL: "http://substrate:8080/seamlessm4t/v1/transcribe"
   depends_on: "substrate": true
 }
 


### PR DESCRIPTION
Fix faster-whisper and seamlessm4t tests to run via substrate gateway.

These tests didn't work directly against the substrate gateway before because the generated docker compose yaml was missing proper network configuration for tests.