### PR TITLE
chore: pass through a mime_type for audio

### DIFF
--- a/images/bridge/pkg/router/types.go
+++ b/images/bridge/pkg/router/types.go
@@ -27,9 +27,15 @@ type TranscriptionSegment struct {
 	IsAssistant bool   `json:"is_assistant"`
 }
 
+type AudioMetadata struct {
+	MimeType   string `json:"mime_type,omitempty"`
+}
+
 type TranscriptionRequest struct {
 	AudioData *[]byte `json:"audio_data,omitempty"`
 	Text      *string `json:"text,omitempty"`
+
+	AudioMetadata AudioMetadata `json:"audio_metadata,omitempty"`
 
 	Task           string  `json:"task"`
 	SourceLanguage *string `json:"source_language,omitempty"`

--- a/images/bridge/pkg/transcriber/transcriber.go
+++ b/images/bridge/pkg/transcriber/transcriber.go
@@ -41,6 +41,9 @@ func Run(s *asr.Client, transcriptionStream chan<- *router.Transcription, audioS
 
 		response, err := s.Transcribe(&router.TranscriptionRequest{
 			AudioData: &audioData,
+			AudioMetadata: router.AudioMetadata {
+				MimeType:   "audio/ogg",
+			},
 			Task:      "transcribe",
 		})
 

--- a/images/bridge2/transcribe/transcribe.go
+++ b/images/bridge2/transcribe/transcribe.go
@@ -38,6 +38,9 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 	transcription, err := a.Transcribe(&Request{
 		Task:      "transcribe",
 		AudioData: &b,
+		AudioMetadata: AudioMetadata {
+			MimeType:   "audio/wav",
+		},
 	})
 	if err != nil {
 		log.Println("transcribe:", err)
@@ -73,9 +76,14 @@ func (a *Agent) Transcribe(request *Request) (*Transcription, error) {
 	}
 }
 
+type AudioMetadata struct {
+	MimeType   string `json:"mime_type,omitempty"`
+}
+
 type Request struct {
-	AudioData *[]byte `json:"audio_data,omitempty"`
-	Task      string  `json:"task"`
+	AudioData     *[]byte       `json:"audio_data,omitempty"`
+	AudioMetadata AudioMetadata `json:"audio_metadata,omitempty"`
+	Task          string        `json:"task"`
 }
 
 type Transcription struct {

--- a/images/faster-whisper/Dockerfile
+++ b/images/faster-whisper/Dockerfile
@@ -5,7 +5,6 @@ FROM docker.io/nvidia/cuda:${CUDA_IMAGE}
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     python3 python3-pip git \
-    libsndfile-dev \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/images/tests/transcriber/test.go
+++ b/images/tests/transcriber/test.go
@@ -27,6 +27,9 @@ func main() {
 	request := &TranscriptionRequest{
 		Task:      "transcribe",
 		AudioData: &audio,
+		AudioMetadata: AudioMetadata {
+			MimeType:   "audio/ogg",
+		},
 	}
 
 	payloadBytes, err := json.Marshal(request)
@@ -75,9 +78,15 @@ type TranscriptionSegment struct {
 	IsAssistant bool   `json:"is_assistant"`
 }
 
+type AudioMetadata struct {
+	MimeType   string `json:"mime_type,omitempty"`
+}
+
 type TranscriptionRequest struct {
 	AudioData *[]byte `json:"audio_data,omitempty"`
 	Text      *string `json:"text,omitempty"`
+	
+	AudioMetadata AudioMetadata `json:"audio_metadata,omitempty"`
 
 	Task           string  `json:"task"`
 	SourceLanguage *string `json:"source_language,omitempty"`


### PR DESCRIPTION
Also switch faster-whisper to using its internal audio decoding logic.

This also fixes a spurious failure in the faster-whisper transcribe test where we weren't resampling the decoded test.ogg file properly. This didn't affect actual behavior because the .ogg file is decoded at 48000 but bridge2 sends audio as 16000 wav.

The result is slightly more correct and uses fewer deps.