### PR TITLE
refactor: substrate activityspec should match RFC

### DIFF
--- a/images/substrate/activityspec/service.go
+++ b/images/substrate/activityspec/service.go
@@ -197,8 +197,8 @@ func (p *ServiceSpawnParameter) Format() string {
 const spaceViewCut = "="
 const spaceViewsSep = ";"
 const spaceViewMultiSep = ","
-const viewspecParameterStart = "["
-const viewspecParameterEnd = "]"
+const viewspecParameterStart = "("
+const viewspecParameterEnd = ")"
 
 func ParseServiceSpawnRequest(spec string, forceReadOnly bool, spawnPrefix string) (*ServiceSpawnRequest, string, error) {
 	var lens string


### PR DESCRIPTION
The URL RFC says ( and ) are acceptable for use in paths. It does not list [ and ] as acceptable. So switch to parens.