### PR TITLE
refactor: rename lens => service throughout

### DIFF
--- a/defs/airoboros-l2-13b-2.2.cue
+++ b/defs/airoboros-l2-13b-2.2.cue
@@ -10,7 +10,7 @@ enable: "airoboros-l2-13b-2.2": true
 
 imagespecs: "llama-cpp-python": {}
 
-"lenses": "airoboros-l2-13b-2.2": {
+services: "airoboros-l2-13b-2.2": {
   spawn: {
     image: imagespecs["llama-cpp-python"].image
     environment: {

--- a/defs/bb.cue
+++ b/defs/bb.cue
@@ -31,6 +31,6 @@ tests: "bb": go: {
 
 imagespecs: "bb": {}
 
-lenses: "bb": {
+services: "bb": {
   spawn: {}
 }

--- a/defs/bridge.cue
+++ b/defs/bridge.cue
@@ -4,7 +4,7 @@ enable: "bridge": true
 
 imagespecs: "bridge": {}
 
-"lenses": "bridge": {
+services: "bridge": {
   spawn: {}
   spawn: environment: {
     // BRIDGE_TRANSCRIPTION: "http://substrate:8080/gw/faster-whisper/v1/transcribe"

--- a/defs/bridge2.cue
+++ b/defs/bridge2.cue
@@ -9,7 +9,7 @@ live_edit: "bridge2": bool
 
 imagespecs: "bridge2": {}
 
-lenses: "bridge2": {
+services: "bridge2": {
   spawn: {
     mounts: [
       if live_edit["bridge2"] {

--- a/defs/datasette.cue
+++ b/defs/datasette.cue
@@ -6,7 +6,7 @@ imagespecs: "datasette": {
   build: args: VERSION: "0.64.1"
 }
 
-"lenses": "datasette": {
+services: "datasette": {
   spawn: {}
   spawn: schema: data: type: "space"
 }

--- a/defs/faster-whisper.cue
+++ b/defs/faster-whisper.cue
@@ -28,7 +28,7 @@ tests: "faster-whisper": transcribe: {
 
 imagespecs: "faster-whisper": {}
 
-lenses: "faster-whisper": {
+services: "faster-whisper": {
   spawn: {}
   spawn: {
     environment: {

--- a/defs/files.cue
+++ b/defs/files.cue
@@ -4,7 +4,7 @@ enable: "files": false
 
 imagespecs: "files": {}
 
-"lenses": "files": {
+services: "files": {
   spawn: {}
   spawn: schema: data: type: "space"
 

--- a/defs/gotty.cue
+++ b/defs/gotty.cue
@@ -6,7 +6,7 @@ imagespecs: "gotty": {
   build: target: "dist-alpine"
 }
 
-"lenses": "gotty": {
+services: "gotty": {
   spawn: {
     url_prefix: "/gotty"
     environment: {

--- a/defs/jupyverse.cue
+++ b/defs/jupyverse.cue
@@ -4,7 +4,7 @@ enable: "jupyverse": true
 
 imagespecs: "jupyverse": {}
 
-"lenses": "jupyverse": {
+services: "jupyverse": {
   spawn: parameters: data: type: "space"
 
   space: {

--- a/defs/screenshot.cue
+++ b/defs/screenshot.cue
@@ -4,6 +4,6 @@ enable: "screenshot": false
 
 imagespecs: "screenshot": {}
 
-"lenses": "screenshot": {
+services: "screenshot": {
   spawn: {}
 }

--- a/defs/seamlessm4t.cue
+++ b/defs/seamlessm4t.cue
@@ -24,7 +24,7 @@ tests: "seamlessm4t": transcribe: {
 
 imagespecs: "seamlessm4t": {}
 
-"lenses": "seamlessm4t": {
+services: "seamlessm4t": {
   spawn: {
     environment: {
       MODEL: "/res/model/huggingface/local"

--- a/defs/substrate.cue
+++ b/defs/substrate.cue
@@ -204,11 +204,11 @@ daemons: "substrate": {
   }
 }
 
-"lenses": "substrate": {
+services: "substrate": {
   activities: {
     // attach: {
     //   request: {
-    //     path: "/substrate/v1/collections/:owner/:name/lensspecs/:lensspec"
+    //     path: "/substrate/v1/collections/:owner/:name/servicespecs/:servicespec"
     //     method: "POST"
     //     schema: {
     //       owner: {
@@ -217,7 +217,7 @@ daemons: "substrate": {
     //       name: {
     //         type: "?"
     //       }
-    //       lensspec: {
+    //       servicespec: {
     //         type: "?"
     //       }
     //     }

--- a/defs/substrate/service.cue
+++ b/defs/substrate/service.cue
@@ -1,4 +1,4 @@
-package lens
+package service
 
 #HTTPRequest: {
 	method !: string

--- a/defs/ui.cue
+++ b/defs/ui.cue
@@ -10,7 +10,7 @@ if live_edit["ui"] {
   imagespecs: "ui": build: target: "dev"
 }
 
-lenses: "ui": {
+services: "ui": {
   spawn: {
     url_prefix: "/ui"
 

--- a/defs/visualizer.cue
+++ b/defs/visualizer.cue
@@ -4,7 +4,7 @@ enable: "visualizer": false
 
 imagespecs: "visualizer": {}
 
-"lenses": "visualizer": {
+services: "visualizer": {
   spawn: {}
   spawn: schema: data: type: "space"
 

--- a/docs/miniService/miniService.md
+++ b/docs/miniService/miniService.md
@@ -73,7 +73,7 @@ EXPOSE 5000
 package defs
 enable: "miniService": true
 imagespecs: "miniService": {}
-lenses: "miniService": {
+services: "miniService": {
     spawn: {
     }
 }

--- a/images/README.md
+++ b/images/README.md
@@ -11,7 +11,7 @@ The images are used for:
 
 Substrate dynamically loads services to satisfy incoming HTTP requests. Any traffic that arrives is parsed according to this pattern: `/:service/*rest`.
 
-Consider the URL `/foo/bar`. Substrate will look in the cue files in the top-level `defs/` directory. It will use the value of `#out.#lenses.foo` to determine what container image, command, environment variables, and volume mounts to set.
+Consider the URL `/foo/bar`. Substrate will look in the cue files in the top-level `defs/` directory. It will use the value of `#out.services.foo` to determine what container image, command, environment variables, and volume mounts to set.
 
 If Substrate hasn't already started a matching container, it will launch a new one.
 
@@ -39,7 +39,7 @@ To add a service named `foo`:
 
     imagespecs: "foo": {}
 
-    lenses: "foo": {
+    services: "foo": {
         spawn: {
             environment: {
                 SOME_VARIABLE: "some_value"

--- a/images/bb/cmd/bb/main.go
+++ b/images/bb/cmd/bb/main.go
@@ -54,7 +54,7 @@ func (m *Main) Serve(ctx context.Context) {
 	callDefLoader := calldef.NewLoader(
 		cueloader.NewCueLoader(
 			":defs",
-			cueloader.LookupPathTransform(cue.MakePath(cue.Def("#out"), cue.Def("#lenses"))),
+			cueloader.LookupPathTransform(cue.MakePath(cue.Def("#out"), cue.Str("services"))),
 		),
 	)
 

--- a/images/datasette/README.md
+++ b/images/datasette/README.md
@@ -1,1 +1,1 @@
-Define a lens based on https://github.com/simonw/datasette
+Define a service based on https://github.com/simonw/datasette

--- a/images/substrate/activityspec/service.go
+++ b/images/substrate/activityspec/service.go
@@ -201,10 +201,10 @@ const viewspecParameterStart = "["
 const viewspecParameterEnd = "]"
 
 func ParseServiceSpawnRequest(spec string, forceReadOnly bool, spawnPrefix string) (*ServiceSpawnRequest, string, error) {
-	var lens string
+	var service string
 	var viewspec string
 	var path string
-	if strings.HasPrefix(spec, viewspecParameterStart) { // lens is unknown!
+	if strings.HasPrefix(spec, viewspecParameterStart) { // service is unknown!
 		viewspec = strings.TrimPrefix(spec, viewspecParameterStart)
 		if !strings.HasSuffix(viewspec, viewspecParameterEnd) {
 			split := strings.SplitN(viewspec, "/", 2)
@@ -218,7 +218,7 @@ func ParseServiceSpawnRequest(spec string, forceReadOnly bool, spawnPrefix strin
 		viewspec = strings.TrimSuffix(viewspec, viewspecParameterEnd)
 	} else {
 		var found bool
-		lens, viewspec, found = strings.Cut(spec, viewspecParameterStart)
+		service, viewspec, found = strings.Cut(spec, viewspecParameterStart)
 		if found {
 			if !strings.HasSuffix(viewspec, viewspecParameterEnd) {
 				split := strings.SplitN(viewspec, "/", 2)
@@ -246,7 +246,7 @@ func ParseServiceSpawnRequest(spec string, forceReadOnly bool, spawnPrefix strin
 	}
 
 	r := &ServiceSpawnRequest{
-		ServiceName: lens,
+		ServiceName: service,
 		Parameters:  params,
 		URLPrefix:   spawnPrefix,
 	}

--- a/images/substrate/defset/spawn.go
+++ b/images/substrate/defset/spawn.go
@@ -84,11 +84,11 @@ func (s *DefSet) IsConcrete(req *activityspec.ServiceSpawnRequest) (bool, error)
 func (s *DefSet) resolveServiceDefSpawn(req *activityspec.ServiceSpawnRequest) (cue.Value, error) {
 	serviceDefValue, ok := s.Services[req.ServiceName]
 	if !ok {
-		lenses := []string{}
+		services := []string{}
 		for k := range s.Services {
-			lenses = append(lenses, k)
+			services = append(services, k)
 		}
-		return cue.Value{}, fmt.Errorf("no such service: %q (have %#v)", req.ServiceName, lenses)
+		return cue.Value{}, fmt.Errorf("no such service: %q (have %#v)", req.ServiceName, services)
 	}
 
 	s.CueMu.Lock()

--- a/images/substrate/http/api.go
+++ b/images/substrate/http/api.go
@@ -272,22 +272,22 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 		}
 	})
 
-	handle("GET", "/substrate/v1/lenses/:lens", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
-		lens, err := s.DefSet().ResolveService(req.Context(), p.ByName("lens"))
+	handle("GET", "/substrate/v1/services/:service", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
+		service, err := s.DefSet().ResolveService(req.Context(), p.ByName("service"))
 		if err != nil {
 			return nil, http.StatusInternalServerError, err
 		}
-		if lens == nil {
+		if service == nil {
 			return nil, http.StatusNotFound, err
 		}
-		return lens, http.StatusOK, nil
+		return service, http.StatusOK, nil
 	})
 
 	handle("GET", "/substrate/v1/activities", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
 		query := req.URL.Query()
 		activities, err := s.ListActivities(req.Context(), &substrate.ActivityListRequest{
 			ActivityWhere: substrate.ActivityWhere{
-				Service: httputil.GetValueAsStringPtr(query, "lens"),
+				Service: httputil.GetValueAsStringPtr(query, "service"),
 			},
 			Limit: substrate.LimitFromPtr(httputil.GetValueAsIntPtr(query, "limit")),
 		})
@@ -332,13 +332,13 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 		return result[0], http.StatusOK, nil
 	})
 
-	handle("GET", "/substrate/v1/lenses", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
-		lenses, err := s.DefSet().AllServices(req.Context())
+	handle("GET", "/substrate/v1/services", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
+		services, err := s.DefSet().AllServices(req.Context())
 		if err != nil {
 			return nil, http.StatusInternalServerError, err
 		}
 
-		return lenses, http.StatusOK, nil
+		return services, http.StatusOK, nil
 	})
 
 	handle("GET", "/substrate/v1/spaces", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
@@ -352,7 +352,7 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 				Owner:       httputil.GetValueAsStringPtr(query, "collection_owner"),
 				Name:        httputil.GetValueAsStringPtr(query, "collection_name"),
 				NamePrefix:  httputil.GetValueAsStringPtr(query, "collection_prefix"),
-				ServiceSpec: httputil.GetValueAsStringPtr(query, "collection_lensspec"),
+				ServiceSpec: httputil.GetValueAsStringPtr(query, "collection_servicespec"),
 				IsPublic:    httputil.GetValueAsBoolPtr(query, "collection_public"),
 			},
 		})
@@ -405,10 +405,10 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 		return result[0], http.StatusOK, nil
 	})
 
-	// Attach a lens to a collection
-	handle("POST", "/substrate/v1/collections/:owner/:name/lenses", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
+	// Attach a service to a collection
+	handle("POST", "/substrate/v1/collections/:owner/:name/services", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
 		r := struct {
-			ServiceSpec string         `json:"lensspec"`
+			ServiceSpec string         `json:"servicespec"`
 			IsPublic    bool           `json:"public,omitempty"`
 			Attributes  map[string]any `json:"attributes,omitempty"`
 		}{}
@@ -418,8 +418,8 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 		}
 
 		// TODO take a space spawned by git-export, use it as config for export
-		// TODO does the lensspec accept any inputs other than the collection?
-		// TODO If so, need to create it as needed and return a proper lensspec.
+		// TODO does the servicespec accept any inputs other than the collection?
+		// TODO If so, need to create it as needed and return a proper servicespec.
 		// TODO
 
 		err = s.WriteCollectionMembership(req.Context(), &substrate.CollectionMembership{
@@ -472,12 +472,12 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 		return nil, http.StatusOK, nil
 	})
 
-	// Remove a lens from a collection
-	handle("DELETE", "/substrate/v1/collections/:owner/:name/lenses/:lensspec", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
+	// Remove a service from a collection
+	handle("DELETE", "/substrate/v1/collections/:owner/:name/services/:servicespec", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
 		err := s.DeleteCollectionMembership(req.Context(), &substrate.CollectionMembershipWhere{
 			Owner:       stringPtr(p.ByName("owner")),
 			Name:        stringPtr(p.ByName("name")),
-			ServiceSpec: stringPtr(p.ByName("lensspec")),
+			ServiceSpec: stringPtr(p.ByName("servicespec")),
 		})
 		if err != nil {
 			return nil, http.StatusInternalServerError, err
@@ -514,7 +514,7 @@ func newApiHandler(s *substrate.Substrate) http.Handler {
 		return result[0].Members, http.StatusOK, nil
 	})
 
-	handle("GET", "/substrate/v1/collections/:owner/:name/lensspecs", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
+	handle("GET", "/substrate/v1/collections/:owner/:name/servicespecs", func(req *http.Request, p httprouter.Params) (interface{}, int, error) {
 		query := req.URL.Query()
 
 		name := p.ByName("name")

--- a/images/substrate/substrate/spawn.go
+++ b/images/substrate/substrate/spawn.go
@@ -43,11 +43,6 @@ func (s *Substrate) WriteSpawn(
 				ForkedFromRef: forkedFromRef,
 				ForkedFromID:  forkedFromID,
 				CreatedAt:     now,
-				// InitialService:   &req.ActivitySpec.ServiceName,
-				// InitialMount: &SpaceMount{
-				// 	Name:  viewName,
-				// 	Multi: multi,
-				// },
 			})
 		}
 

--- a/images/substrate/substrate/substrate.go
+++ b/images/substrate/substrate/substrate.go
@@ -55,7 +55,7 @@ func New(
 	defLoader := defset.NewDefLoader(
 		cueloader.NewCueLoader(
 			":defs",
-			cueloader.LookupPathTransform(cue.MakePath(cue.Def("#out"), cue.Def("#lenses"))),
+			cueloader.LookupPathTransform(cue.MakePath(cue.Def("#out"), cue.Str("services"))),
 			cueloader.FillPathEncodeTransform(
 				cue.MakePath(cue.AnyString, cue.Str("spawn").Optional(), cue.Str("parameters"), cue.Str("cpu_memory_total"), cue.Str("resource"), cue.Str("quantity")),
 				cpuMemoryTotalMB,

--- a/images/ui/src/lib/ActivityCard.svelte
+++ b/images/ui/src/lib/ActivityCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getContext, onMount } from 'svelte'
   import CommandPaletteButton from '$lib/CommandPaletteButton.svelte'
-  import type { LensActivity } from '$lib/activities'
+  import type { ServiceActivity } from '$lib/activities'
   import { urls, fetchJSON } from '$lib/activities'
 
   export let data
@@ -18,7 +18,7 @@
 
   // $: isThisMine = owner == $user$
 
-  let activity: LensActivity | undefined
+  let activity: ServiceActivity | undefined
 
   onMount(async () => {
     ({ activity } = await fetchJSON(fetch, urls.api.activity({ activityspec: data.activityspec })));

--- a/images/ui/src/lib/EntitySelections.svelte
+++ b/images/ui/src/lib/EntitySelections.svelte
@@ -2,13 +2,13 @@
   import type {
     EntitySelection,
     CollectionSelection,
-    LensSelection,
+    ServiceSelection,
     SpaceSelection,
     ActivitySelection,
     EventSelection,
   } from '$lib/entities'
   import CardGallery from '$lib/CardGallery.svelte'
-  import LensCard from '$lib/LensCard.svelte'
+  import ServiceCard from '$lib/ServiceCard.svelte'
   import CollectionCard from '$lib/CollectionCard.svelte'
   import SpaceCard from '$lib/SpaceCard.svelte'
   import ActivityCard from '$lib/ActivityCard.svelte'
@@ -23,10 +23,10 @@
         cards: entities,
       })
     },
-    "lens": {
+    "service": {
       component: CardGallery,
-      props: (entities: LensSelection[]) => ({
-        Card: LensCard,
+      props: (entities: ServiceSelection[]) => ({
+        Card: ServiceCard,
         sortCardsBy: "label",
         cards: entities,
       }),

--- a/images/ui/src/lib/EventFeed.svelte
+++ b/images/ui/src/lib/EventFeed.svelte
@@ -54,7 +54,7 @@ export let events = []
             from
             <a href="{urls.ui.space({space: event.forked_from_id})}" class="font-medium text-gray-900">{event.forked_from_id}</a>
           {/if}
-          via {event.lens}
+          via {event.service}
           <span class="whitespace-nowrap"><Ago time={new Date(event.ts)} /></span>
         </span>
 

--- a/images/ui/src/lib/ServiceCard.svelte
+++ b/images/ui/src/lib/ServiceCard.svelte
@@ -22,7 +22,7 @@
 <div>
   <div class="group">
     <div class="aspect-w-4 aspect-h-3 overflow-hidden rounded-lg bg-gray-100 border-2 group-hover:scale-105 group-hover:transition-all group-hover:shadow-md group-hover:shadow-2xl">
-      <a href="{urls.ui.lens({name: data.name})}">
+      <a href="{urls.ui.service({name: data.name})}">
         <!-- <img src="{urls.api.thumbnailPreviewURL({space})}" alt="" class="object-cover object-center"> -->
       </a>
     </div>
@@ -30,12 +30,12 @@
   <div class="mt-4 flex items-center justify-between space-x-2 text-base font-medium text-gray-900">
     <h3 class="overflow-hidden truncate">
       <a
-        href="{urls.ui.lens({name: data.name})}"
+        href="{urls.ui.service({name: data.name})}"
         class="truncate text-ellipsis"
         >{data.label}</a>
     </h3>
     <CommandPaletteButton
-      selection={{user: $user$, lens: data}}
+      selection={{user: $user$, service: data}}
     />
   </div>
 </div>

--- a/images/ui/src/lib/entities.ts
+++ b/images/ui/src/lib/entities.ts
@@ -3,8 +3,8 @@ import { error } from '@sveltejs/kit'
 import {
   urls,
   fetchJSON,
-  processLenses,
-  processLensSpecs,
+  processServices,
+  processServiceSpecs,
   processSpaces,
   processEvents,
   processActivities,
@@ -24,7 +24,7 @@ export interface BaseEntitySelection {
 // TODO make these real
 export type Collection = any
 export type Space = any
-export type Lens = any
+export type Service = any
 export type Event = any
 export type Activity = any
 
@@ -43,9 +43,9 @@ export interface SpaceSelection extends BaseEntitySelection {
   entities: Space[]
 }
 
-export interface LensSelection extends BaseEntitySelection {
-  entityType: "lens"
-  entities: Lens[]
+export interface ServiceSelection extends BaseEntitySelection {
+  entityType: "service"
+  entities: Service[]
 }
 
 export interface EventSelection extends BaseEntitySelection {
@@ -53,7 +53,7 @@ export interface EventSelection extends BaseEntitySelection {
   entities: Event[]
 }
 
-export type EntitySelection = LensSelection | SpaceSelection | CollectionSelection | ActivitySelection | EventSelection
+export type EntitySelection = ServiceSelection | SpaceSelection | CollectionSelection | ActivitySelection | EventSelection
 
 export async function load({ params, url, fetch }) {
   console.log({ params, url })
@@ -76,11 +76,11 @@ export async function load({ params, url, fetch }) {
             entities: processSpaces(spaces),
             label: `${owner}/${id} Spaces`,
           })
-          const lenses = await fetchJSON(fetch, urls.api.collectionLensMembership({ owner, name: id }))
+          const services = await fetchJSON(fetch, urls.api.collectionServiceMembership({ owner, name: id }))
           selections.push({
-            entityType: "lens",
-            entities: processLensSpecs(lenses),
-            label: `${owner}/${id} Lenses`,
+            entityType: "service",
+            entities: processServiceSpecs(services),
+            label: `${owner}/${id} Services`,
           })
         } else {
           const collections = await fetchJSON(fetch, urls.api.collections({ owner }))
@@ -132,12 +132,12 @@ export async function load({ params, url, fetch }) {
     }
   } else {
     switch (type) {
-      case "lenses": {
-        const lenses = await fetchJSON(fetch, urls.api.lenses({}))
+      case "services": {
+        const services = await fetchJSON(fetch, urls.api.services({}))
         selections.push({
-          entityType: "lens",
-          entities: processLenses(lenses),
-          label: `Lenses`,
+          entityType: "service",
+          entities: processServices(services),
+          label: `Services`,
         })
         break
       }

--- a/images/ui/src/routes/+layout.server.ts
+++ b/images/ui/src/routes/+layout.server.ts
@@ -1,18 +1,18 @@
 import { fetchJSON, urls } from '$lib/activities'
-import type { Lens } from '$lib/activities'
+import type { Service } from '$lib/activities'
 
 /** @type {import('./$types').LayoutServerLoad} */
 
 export async function load({ params, locals, fetch }) {
-  let lenses: Record<string, Lens> = {}
+  let services: Record<string, Service> = {}
   try {
-    lenses = await fetchJSON<Record<string, Lens>>(fetch, urls.api.lenses({}))
+    services = await fetchJSON<Record<string, Service>>(fetch, urls.api.services({}))
   } catch (e) {
     console.error(e)
   }
 
   return {
     user: locals.user,
-    lenses,
+    services,
   }
 }

--- a/images/ui/src/routes/+layout.svelte
+++ b/images/ui/src/routes/+layout.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
-  import "../app.css";
+	import "../app.css";
 	import { setContext } from 'svelte'
 	import { writable } from 'svelte/store'
-  import CommandPalette2 from '$lib/CommandPalette2.svelte'
-	import type { Lens, CommandSelection } from '$lib/activities'
+	import CommandPalette2 from '$lib/CommandPalette2.svelte'
+	import type { CommandSelection } from '$lib/activities'
 	import { getCommandSet } from '$lib/activities'
 
 	export let data
@@ -17,7 +17,7 @@
 
 
 	function getCommands(commandSelection?: CommandSelection) {
-		const { context, commands } = getCommandSet(data.lenses, commandSelection)
+		const { context, commands } = getCommandSet(data.services, commandSelection)
 		return commands
 	}
 


### PR DESCRIPTION
The initial term "lens" was used in a previous iteration of substrate that was much more "space" centric. Using multiple "lenses" to interact with a "space" was a useful metaphor. However, people seemed to have trouble remembering the word "lens" and/or what it represented.

We *previously* used the term "service" to refer to always-running processes that defined the core system. These are now called "daemons".

In this latest iteration of substrate we had many "lenses" that didn't actually use spaces at all. We also found ways to switch many of the core "services" into "lenses".

Given our new architecture and all that we've learned, renaming "service" -> "daemon" and "lens" -> "service" is a good trade.

We do this rename now just before we start writing core data structures to disk, to avoid carrying this legacy terms into our data formats.