### PR TITLE
bridge2: terminate audio loop on EOF

### DIFF
--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ajbouh/substrate/images/bridge2/webrtc/trackstreamer"
 	"github.com/fxamacker/cbor/v2"
 	"github.com/gopxl/beep"
-	"github.com/gopxl/beep/speaker"
 	"github.com/gorilla/websocket"
 	"github.com/pion/webrtc/v3"
 	"github.com/pion/webrtc/v3/pkg/media/oggwriter"
@@ -41,7 +40,6 @@ func main() {
 		NumChannels: 1,
 		Precision:   4,
 	}
-	fatal(speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10)))
 
 	engine.Run(
 		Main{
@@ -227,7 +225,10 @@ func (m *Main) StartSession(sess *Session) {
 			// a smaller size we can append incrementally
 			chunk := beep.Take(chunkSize, s)
 			sessTrack.AddAudio(chunk)
-			fatal(chunk.Err())
+			if err := chunk.Err(); err != nil {
+				log.Printf("track %s: %s", track.ID(), err)
+				break
+			}
 		}
 	})
 	sess.peer.HandleSignals()

--- a/images/bridge2/webrtc/trackstreamer/trackstreamer.go
+++ b/images/bridge2/webrtc/trackstreamer/trackstreamer.go
@@ -28,6 +28,7 @@ type TrackStreamer struct {
 	decodeBuf []float32
 	pcm       []float32
 	reader    SampleReader
+	err       error
 }
 
 func New(track RTPReader, format beep.Format) (beep.Streamer, error) {
@@ -46,8 +47,8 @@ func New(track RTPReader, format beep.Format) (beep.Streamer, error) {
 
 var _ beep.Streamer = (*TrackStreamer)(nil)
 
-func (*TrackStreamer) Err() error {
-	return nil
+func (t *TrackStreamer) Err() error {
+	return t.err
 }
 
 func (t *TrackStreamer) Stream(samples [][2]float64) (n int, ok bool) {
@@ -73,6 +74,7 @@ func (t *TrackStreamer) nextPCM() (sample [2]float64, ok bool) {
 		n, err := t.decodeNextPacket(t.decodeBuf)
 		if err != nil {
 			if err == io.EOF {
+				t.err = err
 				return [2]float64{}, false
 			}
 			continue // if we have a bad packet, try to get another


### PR DESCRIPTION
Return an error when the track audio reaches an EOF error. This was not exiting
the audio read loop and continuing to process empty audio chunks for the track,
which led to high CPU usage.

Fixes #150
