### PR TITLE
bridge2: don't start new session on index

### DIFF
--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -238,7 +238,7 @@ func (m *Main) StartSession(sess *Session) {
 // event. Designed to debounce handling for one update at a time. The channel
 // will be closed when the context is cancelled to allow "range" loops over
 // the updates.
-func sessionUpdateHandler(ctx context.Context, sess *Session) chan struct{} {
+func sessionUpdateHandler(ctx context.Context, sess *Session) <-chan struct{} {
 	ch := make(chan struct{}, 1)
 	h := tracks.HandlerFunc(func(e tracks.Event) {
 		if e.Type == "audio" {
@@ -257,6 +257,26 @@ func sessionUpdateHandler(ctx context.Context, sess *Session) chan struct{} {
 	}()
 	sess.Listen(h)
 	return ch
+}
+
+func timeoutUpdateCh(in <-chan struct{}, timeout time.Duration) <-chan struct{} {
+	out := make(chan struct{})
+	go func() {
+		out <- struct{}{} // trigger initial update
+		for {
+			select {
+			case <-time.After(timeout):
+				out <- struct{}{}
+			case _, ok := <-in:
+				if !ok {
+					close(out)
+					return
+				}
+				out <- struct{}{}
+			}
+		}
+	}()
+	return out
 }
 
 func (m *Main) loadSession(ctx context.Context, id string) (*Session, error) {
@@ -312,35 +332,43 @@ func (m *Main) Serve(ctx context.Context) {
 		CheckOrigin: func(r *http.Request) bool { return true },
 	}
 
-	http.HandleFunc("/sessions", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/sessions/new", func(w http.ResponseWriter, r *http.Request) {
 		sess := m.addSession(ctx, tracks.NewSession())
 		http.Redirect(w, r, path.Join(m.basePath, "sessions", string(sess.ID)), http.StatusFound)
 	})
 
 	http.HandleFunc("/sessions/", func(w http.ResponseWriter, r *http.Request) {
-		sessID := filepath.Base(r.URL.Path)
-		sess, err := m.loadSession(ctx, sessID)
-		if err != nil {
-			// TODO different error if we failed to load vs not found
-			log.Printf("error loading session %s: %s", sessID, err)
-			http.Error(w, "not found", http.StatusNotFound)
-			return
-		}
-		updateCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		updateCh := sessionUpdateHandler(updateCtx, sess)
-		select {
-		case updateCh <- struct{}{}: // trigger initial update
-		default:
-		}
-
 		if websocket.IsWebSocketUpgrade(r) {
+			var sess *Session
+			// by default, send updates until the context is cancelled
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			updateCh := ctx.Done()
+			if sessID := strings.TrimPrefix(r.URL.Path, "/sessions/"); sessID != "" {
+				var err error
+				sess, err = m.loadSession(ctx, sessID)
+				if err != nil {
+					// TODO different error if we failed to load vs not found
+					log.Printf("error loading session %s: %s", sessID, err)
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				// with an active session, send updates when new events arrive
+				updateCh = sessionUpdateHandler(ctx, sess)
+			}
+			// if there are no updates, refresh the list of sessions periodically
+			updateCh = timeoutUpdateCh(updateCh, 10*time.Second)
+
 			conn, err := upgrader.Upgrade(w, r, nil)
 			if err != nil {
 				log.Print("upgrade:", err)
 				return
 			}
 			if r.URL.RawQuery == "sfu" {
+				if sess == nil {
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
 				peer, err := sess.sfu.AddPeer(conn)
 				if err != nil {
 					log.Print("peer:", err)

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -133,6 +133,7 @@ func (m *Main) Initialize() {
 	basePath := os.Getenv("SUBSTRATE_URL_PREFIX")
 	// ensure the path starts and ends with a slash for setting <base href>
 	m.basePath = must(url.JoinPath("/", basePath, "/"))
+	log.Println("got basePath", m.basePath, "from SUBSTRATE_URL_PREFIX", basePath)
 	m.port = parsePort(getEnv("PORT", "8080"))
 
 	m.sessionDir = getEnv("BRIDGE_SESSIONS_DIR", "./sessions")
@@ -417,7 +418,9 @@ func (m *Main) Serve(ctx context.Context) {
 			http.NotFound(w, r)
 			return
 		}
-		http.Redirect(w, r, path.Join(m.basePath, "sessions"), http.StatusFound)
+		// We need the trailing slash in order to go directly to the /sessions/
+		// handler without an extra redirect, but path.Join strips it by default.
+		http.Redirect(w, r, path.Join(m.basePath, "sessions")+"/", http.StatusFound)
 	})
 
 	log.Printf("running on http://localhost:%d ...", m.port)

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -38,16 +38,22 @@ const initSession = () => {
   return sess;
 };
 
-const localMedia = new LocalMedia({
-  videoSource: false,
-  ondevicechange: () => m.redraw(),
-  onstreamchange: (stream) => {
-    if (micSess == null) {
-      micSess = initSession();
-    }
-    micSess.setStream(stream);
-  },
-});
+let localMedia = null;
+const initLocalMedia = () => {
+  if (!localMedia) {
+    localMedia = new LocalMedia({
+      videoSource: false,
+      ondevicechange: () => m.redraw(),
+      onstreamchange: (stream) => {
+        if (micSess == null) {
+          micSess = initSession();
+        }
+        micSess.setStream(stream);
+      },
+    });
+  }
+  return localMedia;
+}
 
 let screenMedia = null;
 
@@ -74,11 +80,12 @@ dataWS.binaryType = 'arraybuffer';
 dataWS.onmessage = e => {
   const data = CBOR.decode((new Uint8Array(e.data)).buffer);
 
-  const events = data.Session.Tracks.map(t => t.Events).filter(e => e).flat();
-  const sessionStart = new Date(data.Session.Start).getTime();
+  const events = data.Session == null ? [] : data.Session.Tracks.map(t => t.Events).filter(e => e).flat();
+  const sessionStart = data.Session && new Date(data.Session.Start).getTime();
 
   viewModel = {
     sessions: data.Sessions,
+    activeSession: data.Session,
     entries: events.filter(e => e.Type === "transcription").sort((a, b) => {
       return a.Start - b.Start;
     }).map(t => {
@@ -91,20 +98,28 @@ dataWS.onmessage = e => {
   }
   m.redraw()
   setTimeout(() => {
-    let elt = document.getElementById("entries");
-    elt.lastChild.scrollIntoView({ block: "end", behavior: 'smooth' })
+    const elt = document.getElementById("entries");
+    if (elt && elt.lastChild) {
+      elt.lastChild.scrollIntoView({ block: "end", behavior: 'smooth' })
+    }
   }, 0);
 }
 
 m.mount(document.body, {
   view: () => [
-    m(Sidebar, {sessions: viewModel.sessions}),
+    m(Sidebar, {activeSession: viewModel.activeSession, sessions: viewModel.sessions}),
     m("div", {"class":"flex flex-col mx-auto grow"},
-      [
-        m(Topbar, {localMedia, shareScreen}),
-        m("div", {"class":"grow px-6 mt-4 overflow-auto","id":"session"},
-          m(Session, {summary: "Summary", entries: viewModel.entries})
-        )
+      viewModel.activeSession ?
+        [
+          m(Topbar, {localMedia: initLocalMedia(), shareScreen, activeSession: viewModel.activeSession}),
+          m("div", {"class":"grow px-6 mt-4 overflow-auto","id":"session"},
+            m(Session, {summary: "Summary", entries: viewModel.entries})
+          )
+        ]
+      : [
+        m("div", {"class": "grow px-6 mt-4"}, [
+          m("a", {"href": "./sessions/new", "class": "rounded border border-2 px-3 py-2"}, "New session")
+        ])
       ]
     )
   ],

--- a/images/bridge2/ui/sidebar.js
+++ b/images/bridge2/ui/sidebar.js
@@ -8,7 +8,7 @@ export var Sidebar = {
             m("h1", {"class":"py-1 text-xl font-bold grow"},
               "bridge"
             ),
-            m("a", {"class":"py-2","href":"./sessions"},
+            m("a", {"class":"py-2","href":"./sessions/new"},
               m("svg", {"class":"feather feather-plus-square","xmlns":"http://www.w3.org/2000/svg","width":"24","height":"24","viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","stroke-width":"2","stroke-linecap":"round","stroke-linejoin":"round"},
                 [
                   m("rect", {"x":"3","y":"3","width":"18","height":"18","rx":"2","ry":"2"}),
@@ -19,11 +19,15 @@ export var Sidebar = {
             )
           ]
         ),
-        ...sessions.map(s => m("div", {"class":"px-6 py-2"},
-          m("a", {"href":`./sessions/${s.ID}`},
-            new Date(s.Start).toLocaleString()
+        ...sessions.map(s => {
+          console.log("session", s.ID, attrs.activeSession);
+          const active = attrs.activeSession && s.ID === attrs.activeSession.ID;
+          return m("div", {"class": "px-6 py-2" + (active ? " bg-gray-800": "")},
+            m("a", {"href":`./sessions/${s.ID}`},
+              new Date(s.Start).toLocaleString()
+            )
           )
-        ))
+        })
       ]
     )
   }

--- a/images/bridge2/ui/topbar.js
+++ b/images/bridge2/ui/topbar.js
@@ -4,7 +4,7 @@ export var Topbar = {
     return m("div", {"class":"flex flex-wrap px-6 py-4","id":"topbar"},
       [
         m("h1", {"class":"py-1 text-xl font-bold"},
-          "session1"
+          new Date(attrs.activeSession.Start).toLocaleString()
         ),
         m("div", {"class":"grow"},
           m.trust("&nbsp;")


### PR DESCRIPTION
It's not always appropriate to start a new session
when loading the index, so move new session
creation to a new path. Adds a button to the index
to start a session, or the user can select a
previous session from the sidebar.

Some other small UI updates to highlight the
active session in the sidebar, and show the
session time instead of "session1" header.

Also adds a timeout for refreshing the list of
sessions when there is not active session, or
there are no new events on the current session.

Fixes #161
