### PR TITLE
bridge2: add translator agent

### DIFF
--- a/defs/bridge2.cue
+++ b/defs/bridge2.cue
@@ -20,6 +20,7 @@ services: "bridge2": {
     ]
     environment: {
       BRIDGE_TRANSCRIBE_URL: "http://substrate:8080/faster-whisper/v1/transcribe",
+      BRIDGE_TRANSLATE_URL: "http://substrate:8080/seamlessm4t/v1/transcribe",
       BRIDGE_SESSIONS_DIR: "/spaces/sessions/tree"
     }
   }

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ajbouh/substrate/images/bridge2/tracks"
 	"github.com/ajbouh/substrate/images/bridge2/transcribe"
+	"github.com/ajbouh/substrate/images/bridge2/translate"
 	"github.com/ajbouh/substrate/images/bridge2/ui"
 	"github.com/ajbouh/substrate/images/bridge2/vad"
 	"github.com/ajbouh/substrate/images/bridge2/webrtc/js"
@@ -51,6 +52,10 @@ func main() {
 		}),
 		transcribe.Agent{
 			Endpoint: getEnv("BRIDGE_TRANSCRIBE_URL", "http://localhost:8090/v1/transcribe"),
+		},
+		translate.Agent{
+			Endpoint:       getEnv("BRIDGE_TRANSLATE_URL", "http://localhost:8091/v1/transcribe"),
+			TargetLanguage: "en",
 		},
 		eventLogger{
 			exclude: []string{"audio"},

--- a/images/bridge2/translate/translate.go
+++ b/images/bridge2/translate/translate.go
@@ -1,0 +1,112 @@
+package translate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/ajbouh/substrate/images/bridge2/tracks"
+	"github.com/ajbouh/substrate/images/bridge2/transcribe"
+)
+
+var recordTranslation = tracks.EventRecorder[*TranslationEvent]("translation")
+
+type TranslationEvent struct {
+	SourceEvent tracks.ID
+	Translation *Translation
+}
+
+type Agent struct {
+	Endpoint       string
+	TargetLanguage string
+}
+
+func (a *Agent) HandleEvent(annot tracks.Event) {
+	if annot.Type != "transcription" {
+		return
+	}
+
+	in := annot.Data.(*transcribe.Transcription)
+	// This doesn't account for fuzzy matching, so SourceLanguage
+	// comes back as "en", but the canonical for target seems to be "eng".
+	if in.SourceLanguage == a.TargetLanguage {
+		log.Println("skipping translation for:", in, "already in target language", a.TargetLanguage)
+		return
+	}
+
+	r, err := a.Translate(&Request{
+		SourceLanguage: in.SourceLanguage,
+		TargetLanguage: a.TargetLanguage,
+		Text:           in.Text(),
+	})
+	if err != nil {
+		log.Println("translate:", err)
+		return
+	}
+	log.Println("translated", r)
+
+	recordTranslation(annot.Span(), &TranslationEvent{
+		SourceEvent: annot.ID,
+		Translation: r,
+	})
+}
+
+func (a *Agent) Translate(request *Request) (*Translation, error) {
+	log.Println("translating", request)
+	payloadBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(a.Endpoint, "application/json", bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
+		response := &Translation{}
+		err = json.Unmarshal(body, response)
+		return response, err
+	} else {
+		return nil, fmt.Errorf("transcribe: %s", body)
+	}
+}
+
+type Request struct {
+	// doesn't seem to be used, but since it's "required", the requests will be rejected without it
+	Task string `json:"task"`
+
+	SourceLanguage string `json:"source_language,omitempty"`
+	TargetLanguage string `json:"target_language,omitempty"`
+	Text           string `json:"text,omitempty"`
+}
+
+type Translation struct {
+	TargetLanguage string    `json:"target_language"`
+	SourceLanguage string    `json:"source_language"`
+	Segments       []Segment `json:"segments"`
+}
+
+func (t Translation) Text() string {
+	var texts []string
+	for _, seg := range t.Segments {
+		texts = append(texts, seg.Text)
+	}
+	return strings.Join(texts, " ")
+}
+
+type Segment struct {
+	Start float32 `json:"start"`
+	End   float32 `json:"end"`
+	Text  string  `json:"text"`
+}

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -83,6 +83,21 @@ dataWS.onmessage = e => {
   const events = data.Session == null ? [] : data.Session.Tracks.map(t => t.Events).filter(e => e).flat();
   const sessionStart = data.Session && new Date(data.Session.Start).getTime();
 
+  const translations = {};
+  for (const e of events) {
+    if (e.Type !== "translation") {
+      continue
+    }
+    const src = e.Data.SourceEvent
+    if (!translations.hasOwnProperty(src)) {
+      translations[src] = []
+    }
+    translations[src].push({
+      lang: e.Data.Translation.target_language,
+      text: e.Data.Translation.segments.map(s => s.text).join(),
+    });
+  }
+
   viewModel = {
     sessions: data.Sessions,
     activeSession: data.Session,
@@ -91,8 +106,11 @@ dataWS.onmessage = e => {
     }).map(t => {
       return {
         speakerLabel: "user",
-        start: new Date(sessionStart + (t.Start / 1000000)), // todo: convert
-        text: t.Data.segments.map(s => s.text).join()
+        lang: t.Data.source_language,
+        start: new Date(sessionStart + (t.Start / 1000000)),
+        text: t.Data.segments.map(s => s.text).join(),
+        final: true,
+        translations: translations[t.ID] || [],
       }
     })
   }

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -112,7 +112,7 @@ dataWS.onmessage = e => {
         final: true,
         translations: translations[t.ID] || [],
       }
-    })
+    }).filter(e => e.text.length > 0),
   }
   m.redraw()
   setTimeout(() => {

--- a/images/bridge2/ui/session.js
+++ b/images/bridge2/ui/session.js
@@ -21,25 +21,20 @@ export var Entry = {
   view: ({attrs}) => {
     return m("div", {"class":"entry"}, [
       m("div", {"class":"left"},
-        [
-          m("div", {"class":"time"}, formatTime(attrs.start)),
-          // m("div", {"class":"session-time"}, formatSessionTime(attrs.sessionTime))
-        ]
+        m("div", {"class":"time"}, formatTime(attrs.start)),
+        // m("div", {"class":"session-time"}, formatSessionTime(attrs.sessionTime))
       ),
       m("div", {"class":"line","style":{"background-color":attrs.lineColor}},
         m("div", {"class":`right ${attrs.isAssistant ? "assistant": ""}`},
-          [
-            // m("div", {"class":"name"}, attrs.speakerLabel),
-            m("div", {"class":`text ${!attrs.final ? "text-gray-400": ""}`},
-              `(${attrs.lang})`,
-              attrs.text
+          // m("div", {"class":"name"}, attrs.speakerLabel),
+          m("div", {"class": `text ${!attrs.final ? "text-gray-400": ""}`, lang: attrs.lang},
+            attrs.text,
+          ),
+          attrs.translations.map(translation =>
+            m("div", {"class": "text text-cyan-500", lang: translation.lang},
+              translation.text,
             )
-          ].concat(
-            attrs.translations.map(translation => m("div", {"class": "text"},
-              `(${translation.lang})`,
-              translation.text
-            ))
-          )
+          ),
         )
       )
     ])

--- a/images/bridge2/ui/session.js
+++ b/images/bridge2/ui/session.js
@@ -29,11 +29,17 @@ export var Entry = {
       m("div", {"class":"line","style":{"background-color":attrs.lineColor}},
         m("div", {"class":`right ${attrs.isAssistant ? "assistant": ""}`},
           [
-            m("div", {"class":"name"}, attrs.speakerLabel),
+            // m("div", {"class":"name"}, attrs.speakerLabel),
             m("div", {"class":`text ${!attrs.final ? "text-gray-400": ""}`},
+              `(${attrs.lang})`,
               attrs.text
             )
-          ]
+          ].concat(
+            attrs.translations.map(translation => m("div", {"class": "text"},
+              `(${translation.lang})`,
+              translation.text
+            ))
+          )
         )
       )
     ])


### PR DESCRIPTION
Adds an agent to the bridge2 process that watches
for transcription events and sends them to the
translator service.

#63 

UI is just a quick hack right now to make sure it's getting some sensible data. Though I guess if the other stuff seems alright, I could commit the backend with a separate PR for the UI the way it was split out in #84.

Looking at the previous bridge code, it parsed translator environment variables containing the language name and other options. I'm not sure if we want to keep that config at the environment level for what target languages to support. Or #67 had some discussion about adding target languages per-session.