### PR TITLE
bridge2: fix height of main content area

### DIFF
--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -108,7 +108,7 @@ dataWS.onmessage = e => {
 m.mount(document.body, {
   view: () => [
     m(Sidebar, {activeSession: viewModel.activeSession, sessions: viewModel.sessions}),
-    m("div", {"class":"flex flex-col mx-auto grow"},
+    m("div", {"class":"flex flex-col h-screen grow"},
       viewModel.activeSession ?
         [
           m(Topbar, {localMedia: initLocalMedia(), shareScreen, activeSession: viewModel.activeSession}),


### PR DESCRIPTION
By setting the height of the right-pane to the
screen height the session contents will scroll
without scrolling the navigation areas.

Fixes #147
