### PR TITLE
chore: substrate gw uses ; before first parameter

### DIFF
--- a/images/substrate/activityspec/legacy.go
+++ b/images/substrate/activityspec/legacy.go
@@ -1,0 +1,71 @@
+package activityspec
+
+import (
+	"fmt"
+	"strings"
+)
+
+const spaceViewCutLegacy = "="
+const spaceViewsSepLegacy = ";"
+const spaceViewMultiSepLegacy = ","
+const viewspecParameterStartLegacy = "("
+const viewspecParameterEndLegacy = ")"
+
+func IsLegacyServiceSpawnRequestFormat(spec string) bool {
+	return strings.Contains(spec, viewspecParameterStartLegacy)
+}
+
+func ParseLegacyServiceSpawnRequest(spec string, forceReadOnly bool, spawnPrefix string) (*ServiceSpawnRequest, string, error) {
+	var service string
+	var viewspec string
+	var path string
+	if strings.HasPrefix(spec, viewspecParameterStartLegacy) { // service is unknown!
+		viewspec = strings.TrimPrefix(spec, viewspecParameterStartLegacy)
+		if !strings.HasSuffix(viewspec, viewspecParameterEndLegacy) {
+			split := strings.SplitN(viewspec, "/", 1)
+			if len(split) > 1 && !strings.HasSuffix(split[0], viewspecParameterEndLegacy) {
+				return nil, "", fmt.Errorf("bad spec: %q; viewspec=%q split=%#v", spec, viewspec, split)
+			}
+
+			viewspec = split[0]
+			path = "/" + split[1]
+		}
+		viewspec = strings.TrimSuffix(viewspec, viewspecParameterEndLegacy)
+	} else {
+		var found bool
+		service, viewspec, found = strings.Cut(spec, viewspecParameterStartLegacy)
+		if found {
+			if !strings.HasSuffix(viewspec, viewspecParameterEndLegacy) {
+				viewspec, path, found = strings.Cut(viewspec, "/")
+				if found && !strings.HasSuffix(viewspec, viewspecParameterEndLegacy) {
+					return nil, "", fmt.Errorf("bad spec: %q; viewspec=%q path=%#v", spec, viewspec, path)
+				}
+
+				path = "/" + path
+			}
+			viewspec = strings.TrimSuffix(viewspec, viewspecParameterEndLegacy)
+		}
+	}
+
+	params := ServiceSpawnParameterRequests{}
+	if viewspec != "" {
+		for _, fragment := range strings.Split(viewspec, spaceViewsSepLegacy) {
+			k, v, ok := strings.Cut(fragment, spaceViewCutLegacy)
+			if !ok {
+				v = k
+				k = "data"
+			}
+			params[k] = ServiceSpawnParameterRequest(v)
+		}
+	}
+
+	r := &ServiceSpawnRequest{
+		ServiceName: service,
+		Parameters:  params,
+		URLPrefix:   spawnPrefix,
+	}
+
+	fmt.Printf("ParseServiceSpawnRequest %q servicename=%s path=%s %#v\n", spec, service, path, *r)
+
+	return r, path, nil
+}

--- a/images/substrate/activityspec/service.go
+++ b/images/substrate/activityspec/service.go
@@ -1,7 +1,6 @@
 package activityspec
 
 import (
-	"fmt"
 	"net/url"
 	"sort"
 	"strconv"
@@ -194,39 +193,23 @@ func (p *ServiceSpawnParameter) Format() string {
 const spaceViewCut = "="
 const spaceViewsSep = ";"
 const spaceViewMultiSep = ","
-const viewspecParameterStart = "("
-const viewspecParameterEnd = ")"
+const viewspecParameterStart = ";"
 
 func ParseServiceSpawnRequest(spec string, forceReadOnly bool, spawnPrefix string) (*ServiceSpawnRequest, string, error) {
 	var service string
 	var viewspec string
 	var path string
+
 	if strings.HasPrefix(spec, viewspecParameterStart) { // service is unknown!
 		viewspec = strings.TrimPrefix(spec, viewspecParameterStart)
-		if !strings.HasSuffix(viewspec, viewspecParameterEnd) {
-			split := strings.SplitN(viewspec, "/", 2)
-			if len(split) > 1 && !strings.HasSuffix(split[0], viewspecParameterEnd) {
-				return nil, "", fmt.Errorf("bad spec: %q; viewspec=%q split=%#v", spec, viewspec, split)
-			}
-
-			viewspec = split[0]
-			path = "/" + split[1]
-		}
-		viewspec = strings.TrimSuffix(viewspec, viewspecParameterEnd)
+		viewspec, path, _ = strings.Cut(viewspec, "/")
+		path = "/" + path
 	} else {
 		var found bool
 		service, viewspec, found = strings.Cut(spec, viewspecParameterStart)
 		if found {
-			if !strings.HasSuffix(viewspec, viewspecParameterEnd) {
-				split := strings.SplitN(viewspec, "/", 2)
-				if len(split) > 1 && !strings.HasSuffix(split[0], viewspecParameterEnd) {
-					return nil, "", fmt.Errorf("bad spec: %q; viewspec=%q split=%#v", spec, viewspec, split)
-				}
-
-				viewspec = split[0]
-				path = "/" + split[1]
-			}
-			viewspec = strings.TrimSuffix(viewspec, viewspecParameterEnd)
+			viewspec, path, _ = strings.Cut(viewspec, "/")
+			path = "/" + path
 		}
 	}
 
@@ -271,7 +254,7 @@ func (r *ServiceSpawnRequest) Format() (string, bool) {
 	viewspec := strings.Join(fragments, spaceViewsSep)
 	// fmt.Printf("ServiceSpawn() viewspec=%q fragments=%#v r=%#v\n", viewspec, fragments, r)
 
-	return r.ServiceName + viewspecParameterStart + viewspec + viewspecParameterEnd, concrete
+	return r.ServiceName + viewspecParameterStart + viewspec, concrete
 }
 
 func (r ServiceSpawnResolution) Format() (string, bool) {
@@ -288,5 +271,5 @@ func (r ServiceSpawnResolution) Format() (string, bool) {
 	viewspec := strings.Join(spaceFragments, spaceViewsSep)
 	// fmt.Printf("ServiceSpawnResolution() viewspec=%s r=%#v\n", viewspec, r)
 
-	return r.ServiceName + viewspecParameterStart + viewspec + viewspecParameterEnd, r.ServiceName != ""
+	return r.ServiceName + viewspecParameterStart + viewspec, r.ServiceName != ""
 }


### PR DESCRIPTION
We previously used ( and ) to indicate service-level spawn parameters. These were a bit hard on the eyes and make the parser a bit more complex than strictly necessary.

For now we still parse and forward requests using the now "legacy" format.