### PR TITLE
fix: some minor errors from #176

### DIFF
--- a/defs/files.cue
+++ b/defs/files.cue
@@ -13,6 +13,4 @@ services: "files": {
     url_prefix: environment.SUBSTRATE_URL_PREFIX
   }
   spawn: parameters: data: type: "space"
-
-  }
 }

--- a/images/files/main.go
+++ b/images/files/main.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-
-	"github.com/ajbouh/substrate/images/files/assets"
 )
 
 const (


### PR DESCRIPTION
There was a formatting error in files.cue, and
re-ran `go fmt` to remove the broken "assets"
import from the `files` service.
