### PR TITLE
bridge2: assistant agent

### DIFF
--- a/defs/bridge2.cue
+++ b/defs/bridge2.cue
@@ -19,8 +19,9 @@ services: "bridge2": {
       }
     ]
     environment: {
-      BRIDGE_TRANSCRIBE_URL: "http://substrate:8080/faster-whisper/v1/transcribe",
-      BRIDGE_TRANSLATE_URL: "http://substrate:8080/seamlessm4t/v1/transcribe",
+      BRIDGE_TRANSCRIBE_URL: "http://substrate:8080/faster-whisper/v1/transcribe"
+      BRIDGE_TRANSLATE_URL: "http://substrate:8080/seamlessm4t/v1/transcribe"
+      BRIDGE_ASSISTANT_URL: "http://substrate:8080/airoboros-l2-13b-2.2/v1/chat/completions"
       BRIDGE_SESSIONS_DIR: "/spaces/sessions/tree"
     }
   }

--- a/images/bridge2/assistant/assistant.go
+++ b/images/bridge2/assistant/assistant.go
@@ -1,6 +1,12 @@
 package assistant
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
 	"strings"
 
 	"github.com/ajbouh/substrate/images/bridge2/tracks"
@@ -13,10 +19,12 @@ type AssistantEvent struct {
 	SourceEvent tracks.ID
 	Name        string
 	Prompt      string
+	Response    string
+	Error       string
 }
 
 type Agent struct {
-	Assistants map[string]struct{}
+	Assistants map[string]string
 }
 
 func (a *Agent) HandleEvent(annot tracks.Event) {
@@ -26,21 +34,18 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 	in := annot.Data.(*transcribe.Transcription)
 
 	if len(in.Segments) == 0 || len(in.Segments[0].Words) == 0 {
+		log.Printf("assistant: transcription had no segments or words")
 		return
 	}
 	text := strings.TrimSpace(in.Text())
-	names := a.matchAssistant(text)
+	names := a.matchAssistants(text)
+	log.Printf("assistant: matched %v for: %s", names, text)
 	for _, name := range names {
-		out := AssistantEvent{
-			SourceEvent: annot.ID,
-			Name:        name,
-			Prompt:      text,
-		}
-		recordAssistant(annot.Span(), &out)
+		go a.respond(annot, name, text)
 	}
 }
 
-func (a *Agent) matchAssistant(text string) []string {
+func (a *Agent) matchAssistants(text string) []string {
 	var matched []string
 	text = strings.ToLower(text)
 	for name := range a.Assistants {
@@ -49,4 +54,91 @@ func (a *Agent) matchAssistant(text string) []string {
 		}
 	}
 	return matched
+}
+
+func (a *Agent) respond(annot tracks.Event, name, prompt string) {
+	out := AssistantEvent{
+		SourceEvent: annot.ID,
+		Name:        name,
+		Prompt:      prompt,
+	}
+	// TODO get speaker name from transcription
+	log.Printf("assistant: about to call %s", name)
+	resp, err := a.call(name, "user", prompt)
+	if err != nil {
+		log.Printf("assistant: %s error: %v", name, err)
+		out.Error = "error calling assistant"
+	} else {
+		log.Printf("assistant: %s response: %s", name, resp)
+		out.Response = resp
+	}
+	recordAssistant(annot.Span(), &out)
+}
+
+func (a *Agent) call(name, speaker, prompt string) (string, error) {
+	endpoint := a.Assistants[name]
+
+	maxTokens := 4096
+	systemMessage := strings.ReplaceAll(`
+A chat between ASSISTANT (named {}) and a USER.
+
+{} is a conversational, vocal, artificial intelligence assistant.
+
+{}'s job is to converse with humans to help them accomplish goals.
+
+{} is able to help with a wide variety of tasks from answering questions to assisting the human with creative writing.
+
+Overall {} is a powerful system that can help humans with a wide range of tasks and provide valuable insights as well as taking actions for the human.
+`, "{}", name)
+
+	req := ChatCompletionRequest{
+		MaxTokens: maxTokens - len(systemMessage),
+		Messages: []ChatCompletionMessage{
+			{
+				Role:    ChatMessageRoleSystem,
+				Content: systemMessage,
+			},
+			{
+				Role:    ChatMessageRoleUser,
+				Name:    speaker,
+				Content: prompt,
+			},
+		},
+	}
+	resp, err := a.doRequest(endpoint, &req)
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("choices was empty")
+	}
+	if r, err := json.MarshalIndent(resp, "", " "); err == nil {
+		log.Printf("assistant: response: %s", r)
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+func (a *Agent) doRequest(endpoint string, request *ChatCompletionRequest) (*ChatCompletionResponse, error) {
+	payloadBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(endpoint, "application/json", bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("assistant: unexpected status %d: %s", resp.StatusCode, body)
+	}
+	var response ChatCompletionResponse
+	err = json.Unmarshal(body, &response)
+	return &response, err
 }

--- a/images/bridge2/assistant/assistant.go
+++ b/images/bridge2/assistant/assistant.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ajbouh/substrate/images/bridge2/transcribe"
 )
 
-var recordAssistant = tracks.EventRecorder[*AssistantEvent]("assistant")
+var recordAssistantText = tracks.EventRecorder[*AssistantTextEvent]("assistant-text")
 
-type AssistantEvent struct {
+type AssistantTextEvent struct {
 	SourceEvent tracks.ID
 	Name        string
 	Input       string
@@ -61,7 +61,7 @@ func (a *Agent) matchAssistants(text string) []string {
 }
 
 func (a *Agent) respond(annot tracks.Event, name, input string) {
-	out := AssistantEvent{
+	out := AssistantTextEvent{
 		SourceEvent: annot.ID,
 		Name:        name,
 		Input:       input,
@@ -76,7 +76,7 @@ func (a *Agent) respond(annot tracks.Event, name, input string) {
 		log.Printf("assistant: %s response: %s", name, resp)
 		out.Response = resp
 	}
-	recordAssistant(annot.Span(), &out)
+	recordAssistantText(annot.Span(), &out)
 }
 
 func (a *Agent) call(name, speaker, prompt string) (string, error) {

--- a/images/bridge2/assistant/assistant.go
+++ b/images/bridge2/assistant/assistant.go
@@ -1,0 +1,51 @@
+package assistant
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/ajbouh/substrate/images/bridge2/tracks"
+	"github.com/ajbouh/substrate/images/bridge2/transcribe"
+)
+
+var recordAssistant = tracks.EventRecorder[*AssistantEvent]("assistant")
+
+type AssistantEvent struct {
+	SourceEvent tracks.ID
+	Name        string
+	Prompt      string
+}
+
+type Agent struct {
+	Assistants map[string]struct{}
+}
+
+func (a *Agent) HandleEvent(annot tracks.Event) {
+	if annot.Type != "transcription" {
+		return
+	}
+	in := annot.Data.(*transcribe.Transcription)
+
+	if len(in.Segments) == 0 || len(in.Segments[0].Words) == 0 {
+		return
+	}
+	name := in.Segments[0].Words[0].Word
+	name = strings.ToLower(name)
+	name = strings.TrimFunc(name, func(r rune) bool {
+		return !unicode.IsLetter(r)
+	})
+	_, ok := a.Assistants[name]
+	if !ok {
+		return
+	}
+
+	text := strings.TrimSpace(in.Text())
+	_, prompt, _ := strings.Cut(text, " ")
+	out := AssistantEvent{
+		SourceEvent: annot.ID,
+		Name:        name,
+		Prompt:      prompt,
+	}
+
+	recordAssistant(annot.Span(), &out)
+}

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -33,11 +33,17 @@ func makeSegments(text string) []transcribe.Segment {
 	return []transcribe.Segment{s}
 }
 
+type echoClient struct{}
+
+func (e echoClient) Call(speaker, prompt string) (string, error) {
+	return "echo: " + prompt, nil
+}
+
 func TestAssistant(t *testing.T) {
 	a := Agent{
-		Assistants: map[string]struct{}{
-			"bridge": {},
-			"hal":    {},
+		Assistants: map[string]Client{
+			"bridge": echoClient{},
+			"hal":    echoClient{},
 		},
 	}
 
@@ -70,6 +76,7 @@ func TestAssistant(t *testing.T) {
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "bridge bar",
+				Response:    "echo: bridge bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -90,6 +97,7 @@ func TestAssistant(t *testing.T) {
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "Bridge bar",
+				Response:    "echo: Bridge bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -110,6 +118,7 @@ func TestAssistant(t *testing.T) {
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "Bridge, bar",
+				Response:    "echo: Bridge, bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -130,6 +139,7 @@ func TestAssistant(t *testing.T) {
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "hey Bridge, bar",
+				Response:    "echo: hey Bridge, bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -151,6 +161,7 @@ func TestAssistant(t *testing.T) {
 					SourceEvent: tevt.ID,
 					Name:        "bridge",
 					Input:       "hey Bridge and HAL, open the pod bay doors",
+					Response:    "echo: hey Bridge and HAL, open the pod bay doors",
 				},
 			},
 			{
@@ -163,6 +174,7 @@ func TestAssistant(t *testing.T) {
 					SourceEvent: tevt.ID,
 					Name:        "hal",
 					Input:       "hey Bridge and HAL, open the pod bay doors",
+					Response:    "echo: hey Bridge and HAL, open the pod bay doors",
 				},
 			},
 		}

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -68,11 +68,11 @@ func TestAssistant(t *testing.T) {
 		events := es.FetchFor(10 * time.Millisecond)
 		expected := tracks.Event{
 			EventMeta: tracks.EventMeta{
-				Type:  "assistant",
+				Type:  "assistant-text",
 				Start: tevt.Start,
 				End:   tevt.End,
 			},
-			Data: &AssistantEvent{
+			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "bridge bar",
@@ -89,11 +89,11 @@ func TestAssistant(t *testing.T) {
 		events := es.FetchFor(10 * time.Millisecond)
 		expected := tracks.Event{
 			EventMeta: tracks.EventMeta{
-				Type:  "assistant",
+				Type:  "assistant-text",
 				Start: tevt.Start,
 				End:   tevt.End,
 			},
-			Data: &AssistantEvent{
+			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "Bridge bar",
@@ -110,11 +110,11 @@ func TestAssistant(t *testing.T) {
 		events := es.FetchFor(10 * time.Millisecond)
 		expected := tracks.Event{
 			EventMeta: tracks.EventMeta{
-				Type:  "assistant",
+				Type:  "assistant-text",
 				Start: tevt.Start,
 				End:   tevt.End,
 			},
-			Data: &AssistantEvent{
+			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "Bridge, bar",
@@ -131,11 +131,11 @@ func TestAssistant(t *testing.T) {
 		events := es.FetchFor(10 * time.Millisecond)
 		expected := tracks.Event{
 			EventMeta: tracks.EventMeta{
-				Type:  "assistant",
+				Type:  "assistant-text",
 				Start: tevt.Start,
 				End:   tevt.End,
 			},
-			Data: &AssistantEvent{
+			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
 				Input:       "hey Bridge, bar",
@@ -153,11 +153,11 @@ func TestAssistant(t *testing.T) {
 		expected := []tracks.Event{
 			{
 				EventMeta: tracks.EventMeta{
-					Type:  "assistant",
+					Type:  "assistant-text",
 					Start: tevt.Start,
 					End:   tevt.End,
 				},
-				Data: &AssistantEvent{
+				Data: &AssistantTextEvent{
 					SourceEvent: tevt.ID,
 					Name:        "bridge",
 					Input:       "hey Bridge and HAL, open the pod bay doors",
@@ -166,11 +166,11 @@ func TestAssistant(t *testing.T) {
 			},
 			{
 				EventMeta: tracks.EventMeta{
-					Type:  "assistant",
+					Type:  "assistant-text",
 					Start: tevt.Start,
 					End:   tevt.End,
 				},
-				Data: &AssistantEvent{
+				Data: &AssistantTextEvent{
 					SourceEvent: tevt.ID,
 					Name:        "hal",
 					Input:       "hey Bridge and HAL, open the pod bay doors",
@@ -181,7 +181,7 @@ func TestAssistant(t *testing.T) {
 		assert.DeepEqual(t, tevt, events[0], cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
 		assistantEvents := events[1:]
 		slices.SortFunc(assistantEvents, func(a, b tracks.Event) int {
-			return cmp.Compare(a.Data.(*AssistantEvent).Name, b.Data.(*AssistantEvent).Name)
+			return cmp.Compare(a.Data.(*AssistantTextEvent).Name, b.Data.(*AssistantTextEvent).Name)
 		})
 		assert.DeepEqual(t, expected, events[1:], cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
 	})

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -69,7 +69,7 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Prompt:      "bridge bar",
+				Input:       "bridge bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -89,7 +89,7 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Prompt:      "Bridge bar",
+				Input:       "Bridge bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -109,7 +109,7 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Prompt:      "Bridge, bar",
+				Input:       "Bridge, bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -129,7 +129,7 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Prompt:      "hey Bridge, bar",
+				Input:       "hey Bridge, bar",
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -150,7 +150,7 @@ func TestAssistant(t *testing.T) {
 				Data: &AssistantEvent{
 					SourceEvent: tevt.ID,
 					Name:        "bridge",
-					Prompt:      "hey Bridge and HAL, open the pod bay doors",
+					Input:       "hey Bridge and HAL, open the pod bay doors",
 				},
 			},
 			{
@@ -162,7 +162,7 @@ func TestAssistant(t *testing.T) {
 				Data: &AssistantEvent{
 					SourceEvent: tevt.ID,
 					Name:        "hal",
-					Prompt:      "hey Bridge and HAL, open the pod bay doors",
+					Input:       "hey Bridge and HAL, open the pod bay doors",
 				},
 			},
 		}

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -1,0 +1,115 @@
+package assistant
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ajbouh/substrate/images/bridge2/bridgetest"
+	"github.com/ajbouh/substrate/images/bridge2/tracks"
+	"github.com/ajbouh/substrate/images/bridge2/transcribe"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gotest.tools/assert"
+)
+
+func makeSegments(text string) []transcribe.Segment {
+	wordLenS := float32(time.Second) / float32(100*time.Millisecond)
+	words := strings.Split(text, " ")
+	s := transcribe.Segment{
+		ID:    0,
+		Start: 0,
+		End:   float32(len(words)) * wordLenS,
+		Text:  text,
+	}
+	for i, w := range words {
+		s.Words = append(s.Words, transcribe.Word{
+			Start: float32(i) * wordLenS,
+			End:   float32(i+1) * wordLenS,
+			Word:  w,
+		})
+	}
+	return []transcribe.Segment{s}
+}
+
+func TestAssistant(t *testing.T) {
+	a := Agent{
+		Assistants: map[string]struct{}{
+			"bridge": {},
+		},
+	}
+
+	session := tracks.NewSession()
+	track := bridgetest.NewTrackWithSilence(session, 10*time.Millisecond)
+
+	session.Listen(&a)
+	es := bridgetest.AddEventStreamer(session)
+
+	t.Run("does not match assistant name", func(t *testing.T) {
+		tevt := transcribe.RecordTranscription(track, &transcribe.Transcription{
+			Segments: makeSegments("bar"),
+		})
+		events := es.FetchFor(10 * time.Millisecond)
+		assert.DeepEqual(t, []tracks.Event{tevt}, events, cmpopts.IgnoreFields(tracks.Event{}, "track"))
+	})
+
+	t.Run("matches assistant name", func(t *testing.T) {
+		tevt := transcribe.RecordTranscription(track, &transcribe.Transcription{
+			Segments: makeSegments("bridge bar"),
+		})
+		events := es.FetchFor(10 * time.Millisecond)
+		expected := tracks.Event{
+			EventMeta: tracks.EventMeta{
+				Type:  "assistant",
+				Start: tevt.Start,
+				End:   tevt.End,
+			},
+			Data: &AssistantEvent{
+				SourceEvent: tevt.ID,
+				Name:        "bridge",
+				Prompt:      "bar",
+			},
+		}
+		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
+	})
+
+	t.Run("matches assistant name not case sensistive", func(t *testing.T) {
+		tevt := transcribe.RecordTranscription(track, &transcribe.Transcription{
+			Segments: makeSegments("Bridge bar"),
+		})
+		events := es.FetchFor(10 * time.Millisecond)
+		expected := tracks.Event{
+			EventMeta: tracks.EventMeta{
+				Type:  "assistant",
+				Start: tevt.Start,
+				End:   tevt.End,
+			},
+			Data: &AssistantEvent{
+				SourceEvent: tevt.ID,
+				Name:        "bridge",
+				Prompt:      "bar",
+			},
+		}
+		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
+	})
+
+	t.Run("matches assistant name with punctuation", func(t *testing.T) {
+		tevt := transcribe.RecordTranscription(track, &transcribe.Transcription{
+			Segments: makeSegments("Bridge, bar"),
+		})
+		events := es.FetchFor(10 * time.Millisecond)
+		expected := tracks.Event{
+			EventMeta: tracks.EventMeta{
+				Type:  "assistant",
+				Start: tevt.Start,
+				End:   tevt.End,
+			},
+			Data: &AssistantEvent{
+				SourceEvent: tevt.ID,
+				Name:        "bridge",
+				Prompt:      "bar",
+			},
+		}
+		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
+	})
+
+}

--- a/images/bridge2/assistant/chat.go
+++ b/images/bridge2/assistant/chat.go
@@ -1,0 +1,93 @@
+package assistant
+
+import "encoding/json"
+
+// Usage Represents the total token usage per request to OpenAI.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// Chat message role defined by the OpenAI API.
+const (
+	ChatMessageRoleSystem    = "system"
+	ChatMessageRoleUser      = "user"
+	ChatMessageRoleAssistant = "assistant"
+	ChatMessageRoleFunction  = "function"
+)
+
+type FinishReason string
+
+const (
+	FinishReasonStop          FinishReason = "stop"
+	FinishReasonLength        FinishReason = "length"
+	FinishReasonFunctionCall  FinishReason = "function_call"
+	FinishReasonContentFilter FinishReason = "content_filter"
+	FinishReasonNull          FinishReason = "null"
+)
+
+func (r FinishReason) MarshalJSON() ([]byte, error) {
+	if r == FinishReasonNull || r == "" {
+		return []byte("null"), nil
+	}
+	// return []byte(`"` + string(r) + `"`), nil // best effort to not break future API changes
+	return json.Marshal(string(r))
+}
+
+type ChatCompletionMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+
+	// This property isn't in the official documentation, but it's in
+	// the documentation for the official library for python:
+	// - https://github.com/openai/openai-python/blob/main/chatml.md
+	// - https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
+	Name string `json:"name,omitempty"`
+
+	// FunctionCall *FunctionCall `json:"function_call,omitempty"`
+}
+
+// ChatCompletionRequest represents a request structure for chat completion API.
+type ChatCompletionRequest struct {
+	Model       string                  `json:"model"`
+	Messages    []ChatCompletionMessage `json:"messages"`
+	MaxTokens   int                     `json:"max_tokens,omitempty"`
+	Temperature float32                 `json:"temperature,omitempty"`
+	TopP        float32                 `json:"top_p,omitempty"`
+	N           int                     `json:"n,omitempty"`
+	// Stream           bool                    `json:"stream,omitempty"`
+	Stop             []string `json:"stop,omitempty"`
+	PresencePenalty  float32  `json:"presence_penalty,omitempty"`
+	FrequencyPenalty float32  `json:"frequency_penalty,omitempty"`
+	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
+	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
+	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias
+	LogitBias map[string]int `json:"logit_bias,omitempty"`
+	User      string         `json:"user,omitempty"`
+	// Functions    []FunctionDefinition `json:"functions,omitempty"`
+	FunctionCall any `json:"function_call,omitempty"`
+}
+
+type ChatCompletionChoice struct {
+	Index   int                   `json:"index"`
+	Message ChatCompletionMessage `json:"message"`
+	// FinishReason
+	// stop: API returned complete message,
+	// or a message terminated by one of the stop sequences provided via the stop parameter
+	// length: Incomplete model output due to max_tokens parameter or token limit
+	// function_call: The model decided to call a function
+	// content_filter: Omitted content due to a flag from our content filters
+	// null: API response still in progress or incomplete
+	FinishReason FinishReason `json:"finish_reason"`
+}
+
+// ChatCompletionResponse represents a response structure for chat completion API.
+type ChatCompletionResponse struct {
+	ID      string                 `json:"id"`
+	Object  string                 `json:"object"`
+	Created int64                  `json:"created"`
+	Model   string                 `json:"model"`
+	Choices []ChatCompletionChoice `json:"choices"`
+	Usage   Usage                  `json:"usage"`
+}

--- a/images/bridge2/assistant/chat.go
+++ b/images/bridge2/assistant/chat.go
@@ -1,3 +1,6 @@
+// JSON model forked from `go-openai` under the Apache 2.0 license
+// https://github.com/sashabaranov/go-openai
+// http://www.apache.org/licenses/LICENSE-2.0
 package assistant
 
 import "encoding/json"

--- a/images/bridge2/bridgetest/bridgetest.go
+++ b/images/bridge2/bridgetest/bridgetest.go
@@ -1,0 +1,53 @@
+package bridgetest
+
+import (
+	"context"
+	"time"
+
+	"github.com/ajbouh/substrate/images/bridge2/tracks"
+	"github.com/gopxl/beep"
+	"github.com/gopxl/beep/generators"
+)
+
+func NewTrackWithSilence(session *tracks.Session, dur time.Duration) *tracks.Track {
+	rate := beep.SampleRate(48000)
+	track := session.NewTrackAt(0, beep.Format{
+		SampleRate:  rate,
+		NumChannels: 2,
+		Precision:   2,
+	})
+	track.AddAudio(generators.Silence(rate.N(dur)))
+	return track
+}
+
+type EventStreamer struct {
+	ch chan tracks.Event
+}
+
+func (es *EventStreamer) HandleEvent(annot tracks.Event) {
+	es.ch <- annot
+}
+
+func (es *EventStreamer) Fetch(ctx context.Context) []tracks.Event {
+	var out []tracks.Event
+	for {
+		select {
+		case <-ctx.Done():
+			return out
+		case e := <-es.ch:
+			out = append(out, e)
+		}
+	}
+}
+
+func (es *EventStreamer) FetchFor(dur time.Duration) []tracks.Event {
+	ctx, cancel := context.WithTimeout(context.Background(), dur)
+	defer cancel()
+	return es.Fetch(ctx)
+}
+
+func AddEventStreamer(s *tracks.Session) *EventStreamer {
+	es := &EventStreamer{ch: make(chan tracks.Event)}
+	s.Listen(es)
+	return es
+}

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -59,8 +59,8 @@ func main() {
 			TargetLanguage: "en",
 		},
 		assistant.Agent{
-			Assistants: map[string]struct{}{
-				"bridge": {},
+			Assistants: map[string]string{
+				"bridge": getEnv("BRIDGE_ASSISTANT_URL", "http://localhost:8092/v1/assistant"),
 			},
 		},
 		eventLogger{
@@ -87,7 +87,7 @@ func (l eventLogger) HandleEvent(e tracks.Event) {
 			return
 		}
 	}
-	log.Printf("event: %s %s %s-%s", e.Type, e.ID, time.Duration(e.Start), time.Duration(e.End))
+	log.Printf("event: %s %s %s-%s %#v", e.Type, e.ID, time.Duration(e.Start), time.Duration(e.End), e.Data)
 }
 
 type Main struct {

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -59,8 +59,11 @@ func main() {
 			TargetLanguage: "en",
 		},
 		assistant.Agent{
-			Assistants: map[string]string{
-				"bridge": getEnv("BRIDGE_ASSISTANT_URL", "http://localhost:8092/v1/assistant"),
+			Assistants: map[string]assistant.Client{
+				"bridge": &assistant.OpenAIClient{
+					Endpoint:      getEnv("BRIDGE_ASSISTANT_URL", "http://localhost:8092/v1/assistant"),
+					SystemMessage: assistant.DefaultSystemMessageForName("bridge"),
+				},
 			},
 		},
 		eventLogger{

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ajbouh/substrate/images/bridge2/assistant"
 	"github.com/ajbouh/substrate/images/bridge2/tracks"
 	"github.com/ajbouh/substrate/images/bridge2/transcribe"
 	"github.com/ajbouh/substrate/images/bridge2/translate"
@@ -56,6 +57,11 @@ func main() {
 		translate.Agent{
 			Endpoint:       getEnv("BRIDGE_TRANSLATE_URL", "http://localhost:8091/v1/transcribe"),
 			TargetLanguage: "en",
+		},
+		assistant.Agent{
+			Assistants: map[string]struct{}{
+				"bridge": {},
+			},
 		},
 		eventLogger{
 			exclude: []string{"audio"},

--- a/images/bridge2/transcribe/transcribe.go
+++ b/images/bridge2/transcribe/transcribe.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ajbouh/substrate/images/bridge2/tracks"
 )
 
-var recordTranscription = tracks.EventRecorder[*Transcription]("transcription")
+var RecordTranscription = tracks.EventRecorder[*Transcription]("transcription")
 
 type Agent struct {
 	Endpoint string
@@ -47,7 +47,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 		return
 	}
 
-	recordTranscription(annot.Span(), transcription)
+	RecordTranscription(annot.Span(), transcription)
 }
 
 func (a *Agent) Transcribe(request *Request) (*Transcription, error) {

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -84,18 +84,32 @@ dataWS.onmessage = e => {
   const sessionStart = data.Session && new Date(data.Session.Start).getTime();
 
   const translations = {};
+  const assistants = {};
   for (const e of events) {
-    if (e.Type !== "translation") {
-      continue
+    let src;
+    switch (e.Type) {
+    case "translation":
+      src = e.Data.SourceEvent
+      if (!translations.hasOwnProperty(src)) {
+        translations[src] = []
+      }
+      translations[src].push({
+        lang: e.Data.Translation.target_language,
+        text: e.Data.Translation.segments.map(s => s.text).join(),
+      });
+      break;
+    case "assistant":
+      src = e.Data.SourceEvent
+      if (!assistants.hasOwnProperty(src)) {
+        assistants[src] = []
+      }
+      assistants[src].push({
+        name: e.Data.Name,
+        text: e.Data.Response,
+        error: e.Data.Error,
+      });
+      break;
     }
-    const src = e.Data.SourceEvent
-    if (!translations.hasOwnProperty(src)) {
-      translations[src] = []
-    }
-    translations[src].push({
-      lang: e.Data.Translation.target_language,
-      text: e.Data.Translation.segments.map(s => s.text).join(),
-    });
   }
 
   viewModel = {
@@ -111,6 +125,9 @@ dataWS.onmessage = e => {
         text: t.Data.segments.map(s => s.text).join(),
         final: true,
         translations: translations[t.ID] || [],
+        // right now these are in response to a single message, though in the
+        // future we may have some entries that are out of band
+        assistants: assistants[t.ID] || [],
       }
     }).filter(e => e.text.length > 0),
   }

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -98,7 +98,7 @@ dataWS.onmessage = e => {
         text: e.Data.Translation.segments.map(s => s.text).join(),
       });
       break;
-    case "assistant":
+    case "assistant-text":
       src = e.Data.SourceEvent
       if (!assistants.hasOwnProperty(src)) {
         assistants[src] = []

--- a/images/bridge2/ui/session.js
+++ b/images/bridge2/ui/session.js
@@ -35,6 +35,12 @@ export var Entry = {
               translation.text,
             )
           ),
+          attrs.assistants.map(asst =>
+            m("div", {"class": "text text-fuchsia-500"},
+              m("b", asst.name),
+              asst.text,
+            )
+          ),
         )
       )
     ])


### PR DESCRIPTION
Adds a basic assistant agent. Right now configuration is mostly hard-coded to include the "bridge" assistant. More could be added to the map, but we can address runtime configuration in #190.
It looks for the assistant name anywhere in the message and passes just the current message to the configured URL using the OpenAI API.

Fixes #64
