### PR TITLE
bridge2: use Go 1.22 http routing patterns

### DIFF
--- a/go.work
+++ b/go.work
@@ -6,7 +6,7 @@ use (
 	./images/sigar
 	./images/nvml
 	./images/bridge
-	./images/bridge2
+	// ./images/bridge2
 	./images/files
 	./images/screenshot
 	./images/substrate

--- a/images/bridge2/Dockerfile
+++ b/images/bridge2/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/golang:1.21 as builder
+FROM docker.io/library/golang:1.22 as builder
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    pkg-config \
-    libopus-dev \
-    libopusfile-dev \
-    libasound2-dev \
+  pkg-config \
+  libopus-dev \
+  libopusfile-dev \
+  libasound2-dev \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /go/src/github.com/ajbouh/substrate/images/bridge2
 COPY images/bridge2/go.mod images/bridge2/go.sum .

--- a/images/bridge2/go.mod
+++ b/images/bridge2/go.mod
@@ -1,6 +1,6 @@
 module github.com/ajbouh/substrate/images/bridge2
 
-go 1.21.1
+go 1.22
 
 require (
 	github.com/fxamacker/cbor/v2 v2.5.0

--- a/images/bridge2/go.work
+++ b/images/bridge2/go.work
@@ -1,0 +1,7 @@
+go 1.22
+
+toolchain go1.22.1
+
+use (
+	.
+)

--- a/images/bridge2/go.work.sum
+++ b/images/bridge2/go.work.sum
@@ -1,0 +1,17 @@
+github.com/ebitengine/oto/v3 v3.1.0/go.mod h1:IK1QTnlfZK2GIB6ziyECm433hAdTaPpOsGMLhEyEGTg=
+github.com/ebitengine/purego v0.5.0/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
+github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRSVop0eemFmo=
+github.com/icza/bitio v1.1.0/go.mod h1:0jGnlLAx8MKMr9VGnn/4YrvZiprkvBelsVIbA9Jjr9A=
+github.com/jfreymuth/oggvorbis v1.0.5/go.mod h1:1U4pqWmghcoVsCJJ4fRBKv9peUJMBHixthRlBeD6uII=
+github.com/jfreymuth/vorbis v1.0.2/go.mod h1:DoftRo4AznKnShRl1GxiTFCseHr4zR9BN3TWXyuzrqQ=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mewkiz/flac v1.0.8/go.mod h1:l7dt5uFY724eKVkHQtAJAQSkhpC3helU3RDxN0ESAqo=
+github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14/go.mod h1:QYCFBiH5q6XTHEbWhR0uhR3M9qNPoD2CSQzr0g75kE4=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e/go.mod h1:nBdnFKj15wFbf94Rwfq4m30eAcyY9V/IyKAGQFtqkW0=
+github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -28,7 +28,7 @@ let webSocketURL = (() => {
 let micSess = null;
 let screenSess = null;
 const initSession = () => {
-  let sess = new SFU(`${webSocketURL}?sfu`);
+  let sess = new SFU(`${webSocketURL}/sfu`);
   sess.onclose = (evt) => console.log("Websocket has closed");
   sess.onerror = (evt) => console.log("ERROR: " + evt.data);
   sess.ontrack = ({ streams: [stream], track }) => {
@@ -75,7 +75,7 @@ const shareScreen = () => {
 };
 
 let viewModel = {};
-let dataWS = new WebSocket(`${webSocketURL}?data`);
+let dataWS = new WebSocket(`${webSocketURL}/data`);
 dataWS.binaryType = 'arraybuffer';
 dataWS.onmessage = e => {
   const data = CBOR.decode((new Uint8Array(e.data)).buffer);


### PR DESCRIPTION
Simplify the handler logic by using more specific
route patterns.

Fixes #165
