### PR TITLE
bridge: add/remove assistants

### DIFF
--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -214,8 +214,8 @@ func (s simpleClient) Complete(speaker, prompt string) (string, string, error) {
 
 func TestAssistantAdd(t *testing.T) {
 	a := Agent{
-		NewClient: func(name, prompt string) Client {
-			return simpleClient{name, prompt}
+		NewClient: func(name, prompt string) (Client, error) {
+			return simpleClient{name, prompt}, nil
 		},
 	}
 
@@ -330,16 +330,4 @@ func TestAssistantAdd(t *testing.T) {
 		events = es.FetchFor(10 * time.Millisecond)
 		assert.DeepEqual(t, []tracks.Event{tevt}, events, cmpopts.IgnoreFields(tracks.Event{}, "track"))
 	})
-}
-
-func TestPromptTemplate(t *testing.T) {
-	c := OpenAIClientGenerator("")("hal", "system message")
-	out, err := c.(interface {
-		BuildPrompt(string, string) (string, error)
-	}).BuildPrompt("speaker", "user input")
-	assert.Assert(t, err)
-	assert.Equal(t, out, `system message
-
-USER: user input
-HAL:`)
 }

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -40,6 +40,10 @@ func (e echoClient) AssistantName() string {
 	return string(e)
 }
 
+func (e echoClient) MatchInput(speaker, input string) bool {
+	return matchesAssistantName(e, input)
+}
+
 func (e echoClient) Complete(speaker, prompt string) (string, error) {
 	return "echo: " + prompt, nil
 }
@@ -200,6 +204,10 @@ type simpleClient struct {
 
 func (s simpleClient) AssistantName() string {
 	return s.Name
+}
+
+func (s simpleClient) MatchInput(speaker, input string) bool {
+	return matchesAssistantName(s, input)
 }
 
 func (s simpleClient) Complete(speaker, prompt string) (string, error) {

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -40,12 +40,11 @@ func (e echoClient) AssistantName() string {
 	return string(e)
 }
 
-func (e echoClient) MatchInput(speaker, input string) bool {
-	return matchesAssistantName(e, input)
-}
-
-func (e echoClient) Complete(speaker, prompt string) (string, error) {
-	return "echo: " + prompt, nil
+func (e echoClient) Complete(speaker, prompt string) (string, string, error) {
+	if !matchesAssistantName(e, prompt) {
+		return "", "", ErrNoMatch
+	}
+	return prompt, "echo: " + prompt, nil
 }
 
 func TestAssistant(t *testing.T) {
@@ -84,8 +83,8 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Input:       "bridge bar",
-				Response:    "echo: bridge bar",
+				Prompt:      "bridge bar",
+				Response:    stringPtr("echo: bridge bar"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -105,8 +104,8 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Input:       "Bridge bar",
-				Response:    "echo: Bridge bar",
+				Prompt:      "Bridge bar",
+				Response:    stringPtr("echo: Bridge bar"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -126,8 +125,8 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Input:       "Bridge, bar",
-				Response:    "echo: Bridge, bar",
+				Prompt:      "Bridge, bar",
+				Response:    stringPtr("echo: Bridge, bar"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -147,8 +146,8 @@ func TestAssistant(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "bridge",
-				Input:       "hey Bridge, bar",
-				Response:    "echo: hey Bridge, bar",
+				Prompt:      "hey Bridge, bar",
+				Response:    stringPtr("echo: hey Bridge, bar"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -169,8 +168,8 @@ func TestAssistant(t *testing.T) {
 				Data: &AssistantTextEvent{
 					SourceEvent: tevt.ID,
 					Name:        "bridge",
-					Input:       "hey Bridge and HAL, open the pod bay doors",
-					Response:    "echo: hey Bridge and HAL, open the pod bay doors",
+					Prompt:      "hey Bridge and HAL, open the pod bay doors",
+					Response:    stringPtr("echo: hey Bridge and HAL, open the pod bay doors"),
 				},
 			},
 			{
@@ -182,8 +181,8 @@ func TestAssistant(t *testing.T) {
 				Data: &AssistantTextEvent{
 					SourceEvent: tevt.ID,
 					Name:        "hal",
-					Input:       "hey Bridge and HAL, open the pod bay doors",
-					Response:    "echo: hey Bridge and HAL, open the pod bay doors",
+					Prompt:      "hey Bridge and HAL, open the pod bay doors",
+					Response:    stringPtr("echo: hey Bridge and HAL, open the pod bay doors"),
 				},
 			},
 		}
@@ -206,12 +205,11 @@ func (s simpleClient) AssistantName() string {
 	return s.Name
 }
 
-func (s simpleClient) MatchInput(speaker, input string) bool {
-	return matchesAssistantName(s, input)
-}
-
-func (s simpleClient) Complete(speaker, prompt string) (string, error) {
-	return fmt.Sprintf("%s\n\n%s", s.SystemPrompt, prompt), nil
+func (s simpleClient) Complete(speaker, prompt string) (string, string, error) {
+	if !matchesAssistantName(s, prompt) {
+		return "", "", ErrNoMatch
+	}
+	return prompt, fmt.Sprintf("%s\n\n%s", s.SystemPrompt, prompt), nil
 }
 
 func TestAssistantAdd(t *testing.T) {
@@ -257,8 +255,8 @@ func TestAssistantAdd(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "hal",
-				Input:       "hello hal",
-				Response:    "you are HAL 9000, a sentient computer\n\nhello hal",
+				Prompt:      "hello hal",
+				Response:    stringPtr("you are HAL 9000, a sentient computer\n\nhello hal"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -285,8 +283,8 @@ func TestAssistantAdd(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "hal",
-				Input:       "hello hal",
-				Response:    "you are HAL 9001\n\nhello hal",
+				Prompt:      "hello hal",
+				Response:    stringPtr("you are HAL 9001\n\nhello hal"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))
@@ -314,8 +312,8 @@ func TestAssistantAdd(t *testing.T) {
 			Data: &AssistantTextEvent{
 				SourceEvent: tevt.ID,
 				Name:        "hal",
-				Input:       "hello hal",
-				Response:    "you are HAL 9001\n\nhello hal",
+				Prompt:      "hello hal",
+				Response:    stringPtr("you are HAL 9001\n\nhello hal"),
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{tevt, expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "ID", "track"))

--- a/images/bridge2/assistant/assistant_test.go
+++ b/images/bridge2/assistant/assistant_test.go
@@ -331,3 +331,15 @@ func TestAssistantAdd(t *testing.T) {
 		assert.DeepEqual(t, []tracks.Event{tevt}, events, cmpopts.IgnoreFields(tracks.Event{}, "track"))
 	})
 }
+
+func TestPromptTemplate(t *testing.T) {
+	c := OpenAIClientGenerator("")("hal", "system message")
+	out, err := c.(interface {
+		BuildPrompt(string, string) (string, error)
+	}).BuildPrompt("speaker", "user input")
+	assert.Assert(t, err)
+	assert.Equal(t, out, `system message
+
+USER: user input
+HAL:`)
+}

--- a/images/bridge2/assistant/prompt_fs_sync.go
+++ b/images/bridge2/assistant/prompt_fs_sync.go
@@ -146,10 +146,10 @@ func (a *fsSync) loadPrompt(name string) (*tracks.Event, error) {
 
 func (a *fsSync) savePrompt(in *AssistantPromptEvent) (os.FileInfo, error) {
 	filename := filepath.Join(a.path, in.Name)
-	if in.SystemMessage == "" {
+	if in.PromptTemplate == "" {
 		return nil, os.Remove(filename)
 	}
-	if err := os.WriteFile(filename, []byte(in.SystemMessage), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(in.PromptTemplate), 0644); err != nil {
 		return nil, err
 	}
 	return os.Stat(filename)

--- a/images/bridge2/assistant/prompt_fs_sync.go
+++ b/images/bridge2/assistant/prompt_fs_sync.go
@@ -1,0 +1,143 @@
+package assistant
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	// fsutil "fs"
+
+	"github.com/ajbouh/substrate/images/bridge2/tracks"
+)
+
+type fsSync struct {
+	sess     *tracks.Session
+	path     string
+	pollRate time.Duration
+	prompts  chan tracks.Event
+}
+
+func newFSSync(sess *tracks.Session, path string, pollRate time.Duration) *fsSync {
+	f := &fsSync{
+		sess:     sess,
+		path:     path,
+		pollRate: pollRate,
+		prompts:  make(chan tracks.Event),
+	}
+	go f.sync()
+	return f
+}
+
+func (a *fsSync) HandleEvent(annot tracks.Event) {
+	switch annot.Type {
+	case "assistant-set-prompt":
+		a.prompts <- annot
+	}
+}
+
+func (a *fsSync) sync() {
+	knownFiles := make(map[string]os.FileInfo)
+	inFlight := make(map[tracks.ID]struct{})
+	t := time.NewTicker(a.pollRate)
+	for {
+		select {
+		case <-t.C:
+			latest, err := a.contents()
+			if err != nil {
+				log.Printf("error reading contents of %s: %v", a.path, err)
+				continue
+			}
+			changed, removed := a.diffContents(knownFiles, latest)
+			for _, name := range removed {
+				asstEvent := RemoveAssistant(a.sess.SpanNow(), name)
+				inFlight[asstEvent.ID] = struct{}{}
+			}
+			for _, name := range changed {
+				asstEvent, err := a.loadPrompt(name)
+				if err != nil {
+					log.Printf("error loading prompt from %s: %v", name, err)
+					continue
+				}
+				inFlight[asstEvent.ID] = struct{}{}
+			}
+			knownFiles = latest
+		case asstEvent := <-a.prompts:
+			if _, ok := inFlight[asstEvent.ID]; ok {
+				delete(inFlight, asstEvent.ID)
+			} else {
+				in := asstEvent.Data.(*AssistantPromptEvent)
+				stat, err := a.savePrompt(in)
+				if err != nil {
+					log.Printf("error saving prompt %s: %v", asstEvent.Data.(*AssistantPromptEvent).Name, err)
+					continue
+				}
+				// update the current entry for this file based on what we just wrote
+				// to avoid triggering a duplicate change when polling the file
+				if stat == nil {
+					delete(knownFiles, in.Name)
+				} else {
+					knownFiles[in.Name] = stat
+				}
+			}
+		}
+	}
+}
+
+func sameFile(a, b os.FileInfo) bool {
+	return a.Name() == b.Name() && a.Size() == b.Size() && a.Mode() == b.Mode() && a.ModTime() == b.ModTime()
+}
+
+func (a *fsSync) diffContents(prev, curr map[string]os.FileInfo) (changed []string, removed []string) {
+	for name := range prev {
+		if _, ok := curr[name]; !ok {
+			removed = append(removed, name)
+		}
+	}
+	for name, entry := range curr {
+		if p, ok := prev[name]; !ok || !sameFile(p, entry) {
+			changed = append(changed, name)
+		}
+	}
+	return changed, removed
+}
+
+func (a *fsSync) contents() (map[string]os.FileInfo, error) {
+	contents := make(map[string]os.FileInfo)
+	entries, err := os.ReadDir(a.path)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		contents[entry.Name()] = info
+	}
+	return contents, nil
+}
+
+func (a *fsSync) loadPrompt(name string) (*tracks.Event, error) {
+	filename := filepath.Join(a.path, name)
+	prompt, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	event := AddAssistant(a.sess.SpanNow(), name, string(prompt))
+	return &event, nil
+}
+
+func (a *fsSync) savePrompt(in *AssistantPromptEvent) (os.FileInfo, error) {
+	filename := filepath.Join(a.path, in.Name)
+	if in.SystemMessage == "" {
+		return nil, os.Remove(filename)
+	}
+	if err := os.WriteFile(filename, []byte(in.SystemMessage), 0644); err != nil {
+		return nil, err
+	}
+	return os.Stat(filename)
+}

--- a/images/bridge2/assistant/prompt_fs_sync_test.go
+++ b/images/bridge2/assistant/prompt_fs_sync_test.go
@@ -1,0 +1,73 @@
+package assistant
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ajbouh/substrate/images/bridge2/bridgetest"
+	"github.com/ajbouh/substrate/images/bridge2/tracks"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	// "github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
+)
+
+func TestFSSync(t *testing.T) {
+	path := t.TempDir()
+	session := tracks.NewSession()
+	a := newFSSync(session, path, 10*time.Millisecond)
+	session.Listen(a)
+
+	track := bridgetest.NewTrackWithSilence(session, 10*time.Millisecond)
+	_ = track
+
+	halPromptPath := filepath.Join(path, "hal")
+
+	es := bridgetest.AddEventStreamer(session)
+
+	t.Run("adding assistant writes to file", func(t *testing.T) {
+		span := track.Span(track.End(), track.End())
+		expected := "you are HAL 9000"
+		evt := AddAssistant(span, "hal", expected)
+
+		time.Sleep(2 * time.Millisecond)
+		actual, err := os.ReadFile(halPromptPath)
+		assert.Assert(t, err)
+		assert.Equal(t, expected, string(actual))
+
+		// Make sure we only get the one initial event.
+		// Writing the file shouldn't trigger a duplicate event.
+		events := es.FetchFor(500 * time.Millisecond)
+		assert.DeepEqual(t, []tracks.Event{evt}, events, cmpopts.IgnoreFields(tracks.Event{}, "track"))
+	})
+
+	t.Run("writing to file updates assistant", func(t *testing.T) {
+		newPrompt := "you are HAL 9001"
+		assert.Assert(t, os.WriteFile(halPromptPath, []byte(newPrompt), 0644))
+
+		events := es.FetchFor(500 * time.Millisecond)
+		expected := tracks.Event{
+			EventMeta: tracks.EventMeta{
+				Type: "assistant-set-prompt",
+			},
+			Data: &AssistantPromptEvent{
+				Name:          "hal",
+				SystemMessage: newPrompt,
+			},
+		}
+		assert.DeepEqual(t, []tracks.Event{expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "Start", "End", "ID", "track"))
+	})
+
+	t.Run("removing assistant deletes file", func(t *testing.T) {
+		evt := RemoveAssistant(track.Span(track.End(), track.End()), "hal")
+
+		time.Sleep(10 * time.Millisecond)
+		_, err := os.Stat(halPromptPath)
+		assert.Assert(t, os.IsNotExist(err), "should get a not-exist error: %v", err)
+
+		events := es.FetchFor(500 * time.Millisecond)
+		assert.DeepEqual(t, []tracks.Event{evt}, events, cmpopts.IgnoreFields(tracks.Event{}, "Start", "End", "ID", "track"))
+	})
+}

--- a/images/bridge2/assistant/prompt_fs_sync_test.go
+++ b/images/bridge2/assistant/prompt_fs_sync_test.go
@@ -53,8 +53,8 @@ func TestFSSync(t *testing.T) {
 				Type: "assistant-set-prompt",
 			},
 			Data: &AssistantPromptEvent{
-				Name:          "hal",
-				SystemMessage: newPrompt,
+				Name:           "hal",
+				PromptTemplate: newPrompt,
 			},
 		}
 		assert.DeepEqual(t, []tracks.Event{expected}, events, cmpopts.IgnoreFields(tracks.Event{}, "Start", "End", "ID", "track"))

--- a/images/bridge2/assistant/prompts/complete.tmpl
+++ b/images/bridge2/assistant/prompts/complete.tmpl
@@ -1,8 +1,14 @@
-{{.SystemMessage}}
+{{"{{- with $assistant := "}}{{.AssistantName | printf "%q" }}{{" -}}"}}
+A chat between ASSISTANT (named {{"{{$assistant}}"}}) and a USER.
 
-USER: {{"{{.UserInput}}"}}
-{{.AssistantName | upper}}:
-{{- /*
-dummy comment to ensure any whitespace at the end of the file is
-stripped from the output
-*/ -}}
+{{"{{$assistant}}"}} is a conversational, vocal, artificial intelligence assistant.
+
+{{"{{$assistant}}"}}'s job is to converse with humans to help them accomplish goals.
+
+{{"{{$assistant}}"}} is able to help with a wide variety of tasks from answering questions to assisting the human with creative writing.
+
+Overall {{"{{$assistant}}"}} is a powerful system that can help humans with a wide range of tasks and provide valuable insights as well as taking actions for the human.
+
+USER: {{"{{$.UserInput}}"}}
+{{"{{$assistant | upper}}"}}:
+{{"{{- end -}}"}}

--- a/images/bridge2/assistant/prompts/complete.tmpl
+++ b/images/bridge2/assistant/prompts/complete.tmpl
@@ -1,6 +1,6 @@
 {{.SystemMessage}}
 
-USER: {{.UserInput}}
+USER: {{"{{.UserInput}}"}}
 {{.AssistantName | upper}}:
 {{- /*
 dummy comment to ensure any whitespace at the end of the file is

--- a/images/bridge2/assistant/prompts/prompts.go
+++ b/images/bridge2/assistant/prompts/prompts.go
@@ -14,12 +14,16 @@ var dirEmbed embed.FS
 
 var dir = fs.LiveDir(dirEmbed)
 
+func baseTemplate() *template.Template {
+	return template.New("").Funcs(template.FuncMap{
+		"upper": strings.ToUpper,
+	})
+}
+
 func loadTemplates() (*template.Template, error) {
 	// TODO if we're reading from the embed.FS the contents won't change, so we
 	// should cache this forever
-	return template.New("").Funcs(template.FuncMap{
-		"upper": strings.ToUpper,
-	}).ParseFS(dir, "*.tmpl")
+	return baseTemplate().ParseFS(dir, "*.tmpl")
 }
 
 func Execute(w io.Writer, name string, data any) error {
@@ -34,4 +38,18 @@ func Render(name string, data any) (string, error) {
 	var w strings.Builder
 	err := Execute(&w, name, data)
 	return w.String(), err
+}
+
+func RenderToString(t *template.Template, data any) (string, error) {
+	var w strings.Builder
+	err := t.Execute(&w, data)
+	return w.String(), err
+}
+
+func RenderToTemplate(name string, data any) (*template.Template, error) {
+	s, err := Render(name, data)
+	if err != nil {
+		return nil, err
+	}
+	return baseTemplate().Parse(s)
 }

--- a/images/bridge2/assistant/prompts/prompts.go
+++ b/images/bridge2/assistant/prompts/prompts.go
@@ -46,10 +46,6 @@ func RenderToString(t *template.Template, data any) (string, error) {
 	return w.String(), err
 }
 
-func RenderToTemplate(name string, data any) (*template.Template, error) {
-	s, err := Render(name, data)
-	if err != nil {
-		return nil, err
-	}
-	return baseTemplate().Parse(s)
+func ParseTemplate(tmpl string) (*template.Template, error) {
+	return baseTemplate().Parse(tmpl)
 }

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -64,7 +64,7 @@ func main() {
 		},
 		assistant.Agent{
 			DefaultAssistants: []assistant.Client{
-				newAssistantClient("bridge", assistant.DefaultSystemMessageForName("bridge")),
+				must(newAssistantClient("bridge", must(assistant.DefaultPromptTemplateForName("bridge")))),
 			},
 			NewClient: newAssistantClient,
 		},

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -60,7 +60,7 @@ func main() {
 			TargetLanguage: "en",
 		},
 		assistant.Agent{
-			Assistants: map[string]assistant.Client{
+			DefaultAssistants: map[string]assistant.Client{
 				"bridge": &assistant.OpenAIClient{
 					Endpoint:      getEnv("BRIDGE_ASSISTANT_URL", "http://localhost:8092/v1/assistant"),
 					SystemMessage: assistant.DefaultSystemMessageForName("bridge"),

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -489,7 +489,7 @@ func (m *Main) Serve(ctx context.Context) {
 	http.HandleFunc("POST /sessions/{sessID}/assistants/{name}", func(w http.ResponseWriter, r *http.Request) {
 		sess := m.loadRequestSession(ctx, w, r)
 		name := r.PathValue("name")
-		prompt := r.FormValue("system_prompt")
+		prompt := r.FormValue("prompt_template")
 		assistant.AddAssistant(sess.SpanNow(), name, prompt)
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/images/bridge2/cmd/bridge/main.go
+++ b/images/bridge2/cmd/bridge/main.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"sync"
@@ -197,6 +198,13 @@ func (m *Main) saveSession(sess *Session) error {
 	// 	return err
 	// }
 	return nil
+}
+
+func (m *Main) SessionStoragePath(sess *tracks.Session, scope string) string {
+	dir := filepath.Join(m.sessionDir, string(sess.ID), scope)
+	err := os.MkdirAll(dir, 0744)
+	fatal(err)
+	return dir
 }
 
 func (m *Main) SavedSessions() (info []*tracks.SessionInfo, err error) {

--- a/images/bridge2/ui/commands.js
+++ b/images/bridge2/ui/commands.js
@@ -8,8 +8,8 @@ export const commands = {
 			return fetch(
 				window.location.href + "/assistants/" + encodeURIComponent(name), {
 				method: "POST",
-				headers: {"Content-Type": "application/x-www-form-urlencoded",},
-				body: new URLSearchParams({"system_prompt": prompt}).toString(),
+				headers: {"Content-Type": "application/x-www-form-urlencoded"},
+				body: new URLSearchParams({system_prompt}).toString(),
 			});
 		},
 	},

--- a/images/bridge2/ui/commands.js
+++ b/images/bridge2/ui/commands.js
@@ -1,0 +1,27 @@
+export const commands = {
+	addAssistant: {
+		parameters: {
+			name: { description: "assistant name" },
+			system_prompt: { description: "assistant system prompt" },
+		},
+		run({name, system_prompt}) {
+			return fetch(
+				window.location.href + "/assistants/" + encodeURIComponent(name), {
+				method: "POST",
+				headers: {"Content-Type": "application/x-www-form-urlencoded",},
+				body: new URLSearchParams({"system_prompt": prompt}).toString(),
+			});
+		},
+	},
+	removeAssistant: {
+		parameters: {
+			name: { description: "assistant name" },
+		},
+		run({name}) {
+			return fetch(
+				window.location.href + "/assistants/" + encodeURIComponent(name), {
+				method: "DELETE",
+			});
+		},
+	},
+}

--- a/images/bridge2/ui/commands.js
+++ b/images/bridge2/ui/commands.js
@@ -2,14 +2,14 @@ export const commands = {
 	addAssistant: {
 		parameters: {
 			name: { description: "assistant name" },
-			system_prompt: { description: "assistant system prompt" },
+			prompt_template: { description: "assistant prompt template" },
 		},
-		run({name, system_prompt}) {
+		run({name, prompt_template}) {
 			return fetch(
 				window.location.href + "/assistants/" + encodeURIComponent(name), {
 				method: "POST",
 				headers: {"Content-Type": "application/x-www-form-urlencoded"},
-				body: new URLSearchParams({system_prompt}).toString(),
+				body: new URLSearchParams({prompt_template}).toString(),
 			});
 		},
 	},

--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -7,6 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mithril/2.2.3/mithril.min.js" integrity="sha512-veJyRkYTPP9HJBUEq3oqA1uBzxGA+OiiHkcgT4Nm8Ovg9dNKSxf4mxClYVCkujcxIz+reFruwp4OPsXY10U8UA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/cbor-js@0.1.0/cbor.min.js"></script>
   <script src="./webrtc/localmedia.js"></script>
+  <script src="./ui/substrate-r0.js"></script>
   <link rel="stylesheet" href="./ui/session.css" />
 </head>
 <body class="flex flex-row bg-gray-900 text-white antialiased">
@@ -16,6 +17,9 @@ import {Session} from "./ui/session.js";
 import {Sidebar} from "./ui/sidebar.js";
 import {Topbar} from "./ui/topbar.js";
 import {Session as SFU} from "./webrtc/session.js";
+import {commands} from "./ui/commands.js";
+
+window.substrate.r0.setCommands(commands);
 
 let webSocketURL = (() => {
   let u = new URL(`ws://${location.host}${location.pathname}`);

--- a/images/bridge2/ui/substrate-r0.js
+++ b/images/bridge2/ui/substrate-r0.js
@@ -1,0 +1,18 @@
+window.substrate = {
+    r0: {
+        commands: {
+            index: {},
+            runners: {},
+            run(command, parameters) { return this.runners[command](parameters) },
+        },
+        setCommands(commands) {
+            const index = {}, runners = {}
+            for (const [name, {parameters, returns, run}] of Object.entries(commands)) {
+                runners[name] = (parameters) => run(parameters)
+                index[name] = {parameters, returns}
+            }
+            this.commands.index = index
+            this.commands.runners = runners
+        },
+    }
+}


### PR DESCRIPTION
Enable adding & removing per-session assistants.

To add an assistant we record an event with the name and system prompt, which
then adds that client an agent listening to the session. New events can change
the prompt, or by setting it to an empty string we disable that assistant.

By recording the system prompt as an event we retain a record of the changes
which might be helpful for reviewing the session history.

Prompts are synced with plain text files in a sub-folder `assistant` under the session's storage directory to allow for editing on the filesystem.