### PR TITLE
bridge2: fix bug with double-slash in WS URL

### DIFF
--- a/images/bridge2/ui/session.html
+++ b/images/bridge2/ui/session.html
@@ -26,7 +26,11 @@ let webSocketURL = (() => {
   if (window.location.protocol == "https:") {
     u.protocol = 'wss:'
   }
-  return u.toString();
+  let urlStr = u.toString();
+  if (urlStr.endsWith("/")) {
+    urlStr = urlStr.slice(0, -1);
+  }
+  return urlStr;
 })();
 
 let micSess = null;


### PR DESCRIPTION
A routing change led to having a trailing slash
on the `/sessions/` index page, but computing
the WebSocket URL assumed that it could append
`/data`. This trims the trailing slash so that
the WebSocket URL is correct.
