### PR TITLE
allow cors access to the Caddy server

### DIFF
--- a/os/src/config/overlay.d/50substrateos/etc/caddy/Caddyfile
+++ b/os/src/config/overlay.d/50substrateos/etc/caddy/Caddyfile
@@ -6,6 +6,24 @@
   admin off
 }
 
+(cors) {
+  @cors_preflight method OPTIONS
+  @cors header Origin {args.0}
+
+  handle @cors_preflight {
+    header Access-Control-Allow-Origin "{args.0}"
+    header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE"
+    header Access-Control-Allow-Headers "Content-Type"
+    header Access-Control-Max-Age "3600"
+    respond "" 204
+  }
+
+  handle @cors {
+    header Access-Control-Allow-Origin "{args.0}"
+    header Access-Control-Expose-Headers "Link"
+  }
+}
+
 {$HOSTNAME} {
   redir /debug/shell /debug/shell/
   reverse_proxy /debug/shell/* http://127.0.0.1:8181
@@ -13,5 +31,6 @@
   handle_path /debug/vscode/* {
     reverse_proxy http://127.0.0.1:3001
   }
+  import cors {header.origin}
   reverse_proxy http://127.0.0.1:8080
 }


### PR DESCRIPTION
This helps to access services on device from another computer typically on the same local network.