### PR TITLE
tool-call: add JS client code

### DIFF
--- a/defs/tool-call.cue
+++ b/defs/tool-call.cue
@@ -23,6 +23,7 @@ if live_edit["tool-call"] {
   services: "tool-call": instances: [string]: {
     mounts: [
       { source: "\(#var.host_source_directory)/images/tool-call/prompts", destination: "/go/src/github.com/ajbouh/substrate/images/tool-call/prompts", mode: "ro" },
+      { source: "\(#var.host_source_directory)/images/tool-call/js", destination: "/go/src/github.com/ajbouh/substrate/images/tool-call/js", mode: "ro" },
     ]
   }
 }

--- a/images/chromestage/cmd/chromestage/main.go
+++ b/images/chromestage/cmd/chromestage/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 

--- a/images/substrate/cmd/main.go
+++ b/images/substrate/cmd/main.go
@@ -185,7 +185,6 @@ func main() {
 		&defset.Loader{
 			ServiceDefPath: cue.MakePath(cue.Str("services")),
 		},
-		&substratehttp.PProfHandler{},
 		initialCueLoadConfig(),
 		&cueloader.CueConfigWatcher{
 			ReadyFile: "ready",

--- a/images/tool-call/js/commands.js
+++ b/images/tool-call/js/commands.js
@@ -1,0 +1,36 @@
+export class StaticCommands {
+  constructor(commands) {
+    const index = {},
+      runners = {};
+    for (const [
+      name,
+      { description, parameters, returns, run },
+    ] of Object.entries(commands)) {
+      runners[name] = (parameters) => run(parameters);
+      index[name] = { description, parameters, returns };
+    }
+    this.index = Promise.resolve(index);
+    this.runners = runners;
+  }
+  async run(command, parameters) {
+    return await this.runners[command](parameters);
+  }
+}
+
+export class ReflectCommands {
+  constructor(url) {
+    this.url = url || window.location.href;
+  }
+
+  get index() {
+    return fetch(this.url, { method: "REFLECT" }).then((resp) => resp.json());
+  }
+
+  async run(command, parameters) {
+    return await fetch(this.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command, parameters }),
+    }).then((resp) => resp.json());
+  }
+}

--- a/images/tool-call/js/embed.go
+++ b/images/tool-call/js/embed.go
@@ -1,0 +1,12 @@
+package js
+
+import (
+	"embed"
+
+	"tractor.dev/toolkit-go/engine/fs"
+)
+
+//go:embed *
+var dir embed.FS
+
+var Dir = fs.LiveDir(dir)

--- a/images/tool-call/js/suggest.js
+++ b/images/tool-call/js/suggest.js
@@ -1,0 +1,32 @@
+import { ReflectCommands } from "./commands.js";
+
+export class Suggester {
+  constructor(toolCallURL, commands) {
+    this.commands = commands;
+    this.toolCall = new ReflectCommands(toolCallURL);
+  }
+
+  async suggest(input) {
+    const result = await this.toolCall.run("suggest", {
+      input,
+      commands: await this.commands.index,
+    });
+    console.log("result", result);
+    if (result.error) {
+      throw new Error(`Suggestion error: ${result.error}`);
+    }
+    return result.choices;
+  }
+
+  async run({ command, parameters }) {
+    return await this.commands.run(command, parameters);
+  }
+
+  async suggestAndRun(input) {
+    const choices = await this.suggest(input);
+    if (choices.length === 0) {
+      return null;
+    }
+    return await this.run(choices[0]);
+  }
+}

--- a/images/tool-call/main.go
+++ b/images/tool-call/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"net/http"
 	"os"
 
+	"github.com/ajbouh/substrate/images/tool-call/js"
 	"github.com/ajbouh/substrate/images/tool-call/tools"
 	"github.com/ajbouh/substrate/pkg/toolkit/commands"
 	"github.com/ajbouh/substrate/pkg/toolkit/httpframework"
@@ -22,6 +24,10 @@ func main() {
 		&httpframework.StripPrefix{Prefix: prefix},
 		&commands.HTTPHandler{Route: "/commands"},
 		&commands.Aggregate{},
+		httpframework.Route{
+			Route:   "GET /js/",
+			Handler: http.StripPrefix("/js", http.FileServer(http.FS(js.Dir))),
+		},
 		commands.NewStaticSource[any](
 			[]commands.Entry{{
 				Name: "suggest",

--- a/images/tool-call/main.go
+++ b/images/tool-call/main.go
@@ -22,59 +22,61 @@ func main() {
 		&httpframework.StripPrefix{Prefix: prefix},
 		&commands.HTTPHandler{Route: "/commands"},
 		&commands.Aggregate{},
-		commands.Entry{
-			Name: "suggest",
-			Def: commands.Def{
-				Description: "Suggest a command",
-				Parameters: commands.FieldDefs{
-					"input": {
-						Name:        "input",
-						Type:        "string",
-						Description: "The input to suggest a command for",
+		commands.NewStaticSource[any](
+			[]commands.Entry{{
+				Name: "suggest",
+				Def: commands.Def{
+					Description: "Suggest a command",
+					Parameters: commands.FieldDefs{
+						"input": {
+							Name:        "input",
+							Type:        "string",
+							Description: "The input to suggest a command for",
+						},
+						"commands": {
+							Name:        "commands",
+							Type:        "object",
+							Description: "The commands to suggest from",
+						},
 					},
-					"commands": {
-						Name:        "commands",
-						Type:        "object",
-						Description: "The commands to suggest from",
+					Returns: commands.FieldDefs{
+						"prompt": {
+							Name:        "prompt",
+							Type:        "string",
+							Description: "The prompt provided to the tool suggestion model",
+						},
+						"choices": {
+							Name:        "choices",
+							Type:        "list",
+							Description: "The suggested commands",
+						},
 					},
 				},
-				Returns: commands.FieldDefs{
-					"prompt": {
-						Name:        "prompt",
-						Type:        "string",
-						Description: "The prompt provided to the tool suggestion model",
-					},
-					"choices": {
-						Name:        "choices",
-						Type:        "list",
-						Description: "The suggested commands",
-					},
+				Run: func(ctx context.Context, p commands.Fields) (commands.Fields, error) {
+					input := p.String("input")
+					cmds, err := convertJSON[commands.DefIndex](p["commands"])
+					if err != nil {
+						return nil, err
+					}
+					defs := translateDefs(cmds)
+					prompt, calls, err := tools.Suggest(input, defs)
+					if err != nil {
+						return nil, err
+					}
+					reqs := make([]commands.Request, 0, len(calls))
+					for _, c := range calls {
+						reqs = append(reqs, commands.Request{
+							Command:    c.Name,
+							Parameters: c.Arguments,
+						})
+					}
+					return commands.Fields{
+						"prompt":  prompt,
+						"choices": reqs,
+					}, nil
 				},
-			},
-			Run: func(ctx context.Context, p commands.Fields) (commands.Fields, error) {
-				input := p.String("input")
-				cmds, err := convertJSON[commands.DefIndex](p["commands"])
-				if err != nil {
-					return nil, err
-				}
-				defs := translateDefs(cmds)
-				prompt, calls, err := tools.Suggest(input, defs)
-				if err != nil {
-					return nil, err
-				}
-				reqs := make([]commands.Request, 0, len(calls))
-				for _, c := range calls {
-					reqs = append(reqs, commands.Request{
-						Command:    c.Name,
-						Parameters: c.Arguments,
-					})
-				}
-				return commands.Fields{
-					"prompt":  prompt,
-					"choices": reqs,
-				}, nil
-			},
-		},
+			}},
+		),
 	)
 }
 


### PR DESCRIPTION
Adds a JavaScript client for the `tool-call` service.

Exposes `commands.js` with the core clients for using commands from JavaScript,
along with `suggest.js` with a wrapper to the tool-call suggest command which
handles sending the command index, and optionally invoking the command from the
response.
