### PR TITLE
fix: Decode Event.Response as any

### DIFF
--- a/images/substrate/db/db.go
+++ b/images/substrate/db/db.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/ajbouh/substrate/images/substrate/activityspec"
 )
 
 type DB struct {
@@ -182,10 +180,7 @@ type EventListRequest struct {
 }
 
 type Event struct {
-	// DockerSpawn  *dockerprovisioner.SpawnEvent  `json:"docker_spawn,omitempty"`
-	// DockerStatus *dockerprovisioner.StatusEvent `json:"docker_status,omitempty"`
-
-	Response *activityspec.ServiceSpawnResponse `json:"spawn_response"`
+	Response any `json:"spawn_response"`
 
 	ID           string    `json:"id"`
 	ActivitySpec string    `json:"viewspec,omitempty"`


### PR DESCRIPTION
When we switched resourcedirs to being container images, the mount data structure switched from being a list to being an object. This means we can't deserialize the ServiceSpawnResponse in past events.

So switch to loading it as any. This works for our needs and keeps things both simple and flexible.