### PR TITLE
fix: cors should be handled by substrate gateway

### DIFF
--- a/os/src/config/overlay.d/50substrateos/etc/caddy/Caddyfile
+++ b/os/src/config/overlay.d/50substrateos/etc/caddy/Caddyfile
@@ -6,24 +6,6 @@
   admin off
 }
 
-(cors) {
-  @cors_preflight method OPTIONS
-  @cors header Origin {args.0}
-
-  handle @cors_preflight {
-    header Access-Control-Allow-Origin "{args.0}"
-    header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE REFLECT"
-    header Access-Control-Allow-Headers "Content-Type"
-    header Access-Control-Max-Age "3600"
-    respond "" 204
-  }
-
-  handle @cors {
-    header Access-Control-Allow-Origin "{args.0}"
-    header Access-Control-Expose-Headers "Link"
-  }
-}
-
 {$HOSTNAME}:443 {
   redir /debug/shell /debug/shell/
   reverse_proxy /debug/shell/* http://127.0.0.1:8181
@@ -31,7 +13,6 @@
   handle_path /debug/vscode/* {
     reverse_proxy http://127.0.0.1:3001
   }
-  import cors {header.origin}
   reverse_proxy http://127.0.0.1:8080
 }
 


### PR DESCRIPTION
Also having it in the Caddyfile actually breaks CORS because the headers are present twice.