### PR TITLE
bridge: consume events

### DIFF
--- a/defs/bridge.cue
+++ b/defs/bridge.cue
@@ -18,6 +18,7 @@ services: "bridge": {
     environment: {
       SUBSTRATE_EVENT_WRITER_URL: "http://substrate:8080/events;data=\(parameters.sessions.value)/tree/fields"
       SUBSTRATE_STREAM_URL_PATH: "/events;data=\(parameters.sessions.value)/stream/events"
+      SUBSTRATE_EVENT_STREAM_URL: "http://substrate:8080\(SUBSTRATE_STREAM_URL_PATH)"
       BRIDGE_COMMANDS_URL: "http://substrate:8080/"
       BRIDGE_TRANSCRIBE_COMMAND: "faster-whisper:transcribe-data"
       BRIDGE_TRANSLATE_COMMAND: "seamlessm4t:translate"

--- a/images/bridge/assistant/assistant.go
+++ b/images/bridge/assistant/assistant.go
@@ -153,6 +153,7 @@ func (a *Agent) recordTextEvent(span tracks.Span, data *AssistantTextEvent) {
 	ev := RecordAssistantText(span, data)
 	notify.Later(a.NotifyQueue, a.AssistantTextNotifiers, AssistantTextNotification{
 		EventMeta: ev.EventMeta,
+		TrackID:   ev.Track().ID,
 		Data:      ev.Data.(*AssistantTextEvent),
 	})
 }

--- a/images/bridge/assistant/tools/agent.go
+++ b/images/bridge/assistant/tools/agent.go
@@ -102,6 +102,7 @@ func (a *OfferAgent) HandleEvent(event tracks.Event) {
 		})
 		notify.Later(a.NotifyQueue, a.OfferNotifiers, OfferNotification{
 			EventMeta: ev.EventMeta,
+			TrackID:   event.Track().ID,
 			Data:      ev.Data.(*OfferEvent),
 		})
 	}
@@ -155,6 +156,7 @@ func (a AutoTriggerAgent) HandleEvent(event tracks.Event) {
 		})
 		notify.Later(a.NotifyQueue, a.TriggerNotifiers, TriggerNotification{
 			EventMeta: ev.EventMeta,
+			TrackID:   event.Track().ID,
 			Data:      ev.Data.(*TriggerEvent),
 		})
 	}
@@ -190,6 +192,7 @@ func (a *CallAgent) HandleEvent(event tracks.Event) {
 		})
 		notify.Later(a.NotifyQueue, a.CallNotifiers, CallNotification{
 			EventMeta: ev.EventMeta,
+			TrackID:   ev.Track().ID,
 			Data:      ev.Data.(*CallEvent),
 		})
 	}

--- a/images/bridge/cmd/bridge/main.go
+++ b/images/bridge/cmd/bridge/main.go
@@ -81,7 +81,8 @@ func main() {
 	// don't re-trigger streaming
 	cursorURL := fmt.Sprintf("%s/bridge-cursor/%s", eventWriterURL, sessionID)
 
-	streamQuery := event.QueryLatestByPathPrefix(fmt.Sprintf("bridge/%s/", sessionID))
+	pathPrefix := fmt.Sprintf("/bridge/%s/", sessionID)
+	streamQuery := event.QueryLatestByPathPrefix(pathPrefix)
 	resp, err := http.Get(cursorURL)
 	fatal(err)
 
@@ -104,7 +105,7 @@ func main() {
 	}
 
 	queryParams := url.Values{}
-	queryParams.Set("path_prefix", "bridge/"+sessionID)
+	queryParams.Set("path_prefix", pathPrefix)
 	eventStreamURL := fmt.Sprintf("%s?%s", mustGetenv("SUBSTRATE_STREAM_URL_PATH"), queryParams.Encode())
 
 	engine.Run(

--- a/images/bridge/diarize/diarize.go
+++ b/images/bridge/diarize/diarize.go
@@ -124,6 +124,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 		})
 		notify.Later(a.NotifyQueue, a.SpeakerNameNotifiers, SpeakerNameEvent{
 			EventMeta: ev.EventMeta,
+			TrackID:   ev.Track().ID,
 			Data:      ev.Data.(*SpeakerName),
 		})
 	}
@@ -139,6 +140,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 		})
 		notify.Later(a.NotifyQueue, a.SpeakerDetectedNotifiers, SpeakerDetectedEvent{
 			EventMeta: ev.EventMeta,
+			TrackID:   ev.Track().ID,
 			Data:      ev.Data.(*SpeakerDetected),
 		})
 	}

--- a/images/bridge/go.mod
+++ b/images/bridge/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/elnormous/contenttype v1.0.4 // indirect
 	github.com/go-audio/riff v1.0.0 // indirect
 	github.com/google/uuid v1.3.1 // indirect
+	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/pion/datachannel v1.5.5 // indirect
 	github.com/pion/dtls/v2 v2.2.7 // indirect
 	github.com/pion/ice/v2 v2.3.15 // indirect

--- a/images/bridge/go.sum
+++ b/images/bridge/go.sum
@@ -28,6 +28,9 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pion/datachannel v1.5.5 h1:10ef4kwdjije+M9d7Xm9im2Y3O6A6ccQb0zcqZcJew8=
 github.com/pion/datachannel v1.5.5/go.mod h1:iMz+lECmfdCMqFRhXhcA/219B0SQlbpoR2V118yimL0=
 github.com/pion/dtls/v2 v2.2.7 h1:cSUBsETxepsCSFSxC3mc/aDo14qQLMSL+O6IjG28yV8=

--- a/images/bridge/transcribe/transcribe.go
+++ b/images/bridge/transcribe/transcribe.go
@@ -54,6 +54,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 	ev := RecordTranscription(annot.Span(), transcription)
 	notify.Later(a.NotifyQueue, a.ActivityEventNotifiers, TranscriptionEvent{
 		EventMeta: ev.EventMeta,
+		TrackID:   ev.Track().ID,
 		Data:      transcription,
 	})
 }

--- a/images/bridge/translate/translate.go
+++ b/images/bridge/translate/translate.go
@@ -59,6 +59,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 	})
 	notify.Later(a.NotifyQueue, a.TranslationNotifiers, TranslationEvent{
 		EventMeta: ev.EventMeta,
+		TrackID:   ev.Track().ID,
 		Data:      ev.Data.(*TranslationRecord),
 	})
 }

--- a/images/bridge/vad/vad.go
+++ b/images/bridge/vad/vad.go
@@ -98,6 +98,7 @@ func (a *Agent) HandleEvent(annot tracks.Event) {
 		ev := RecordActivity(annot.Track().Span(start, annot.End))
 		notify.Later(a.NotifyQueue, a.ActivityEventNotifiers, ActivityEvent{
 			EventMeta: ev.EventMeta,
+			TrackID:   ev.Track().ID,
 			Data:      struct{}{}, //*ev.Data.(*struct{}),
 		})
 	}

--- a/pkg/toolkit/event/event.go
+++ b/pkg/toolkit/event/event.go
@@ -55,6 +55,15 @@ func (m *SHA256Digest) Scan(src any) error {
 	return ErrScanValue
 }
 
+func (m *SHA256Digest) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	_, err := hex.Decode(m[:], []byte(s))
+	return err
+}
+
 func (m *SHA256Digest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(m[:]))
 }


### PR DESCRIPTION
Consume the event stream to drive bridge.

Currently, this disables actually triggering events on the bridge
`record<EventType>` calls, and instead waits for the event to come through on
the stream to trigger handlers.
