### PR TITLE
remove pkg/p9 from go.work

### DIFF
--- a/go.work
+++ b/go.work
@@ -18,6 +18,5 @@ use (
 	./images/weather
 	./pkg/cueloader
 	./pkg/toolkit
-	./pkg/p9
 	./pkg/go-vscode
 )


### PR DESCRIPTION
This appears to refer to a package that hasn't been committed yet. I needed to remove this for stuff like gopls to work for local development.