### PR TITLE
test Go command calling

### DIFF
--- a/pkg/toolkit/commands/call.go
+++ b/pkg/toolkit/commands/call.go
@@ -29,10 +29,12 @@ func CallURL[Out, In any](ctx context.Context, env Env, url, command string, par
 	slog.InfoContext(ctx, "CallURL", "url", url, "command", command, "params", paramFields)
 
 	resultFields, err := env.Apply(nil, Fields{
-		"cap":        "reflectedmsg",
-		"url":        url,
-		"name":       command,
-		"parameters": paramFields,
+		"cap":  "reflectedmsg",
+		"url":  url,
+		"name": command,
+		"data": Fields{
+			"parameters": paramFields,
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/toolkit/commands/call.go
+++ b/pkg/toolkit/commands/call.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"reflect"
 )
 
@@ -19,25 +20,29 @@ func convertViaJSON[Out, In any](input In) (Out, error) {
 	return out, err
 }
 
-func CallURL[Out, In any](ctx context.Context, hrr URLReflector, url string, command string, params In) (*Out, error) {
-	runner, _, err := hrr.ReflectURL(ctx, url)
-	if err != nil {
-		return nil, err
-	}
-
-	return CallSource[Out, In](ctx, runner, command, params)
-}
-
-func CallSource[Out, In any](ctx context.Context, src Source, command string, params In) (*Out, error) {
+func CallURL[Out, In any](ctx context.Context, env Env, url, command string, params In) (*Out, error) {
 	paramFields, err := convertViaJSON[Fields](params)
 	if err != nil {
 		return nil, err
 	}
-	resultFields, err := src.Run(ctx, command, paramFields)
+
+	slog.InfoContext(ctx, "CallURL", "url", url, "command", command, "params", paramFields)
+
+	resultFields, err := env.Apply(nil, Fields{
+		"cap":        "reflectedmsg",
+		"url":        url,
+		"name":       command,
+		"parameters": paramFields,
+	})
 	if err != nil {
 		return nil, err
 	}
-	out, err := convertViaJSON[Out](resultFields)
+	returns, err := Get[Fields](resultFields, "returns")
+	if err != nil {
+		return nil, err
+	}
+	out, err := convertViaJSON[Out](returns)
+	slog.InfoContext(ctx, "CallURL", "out", out, "err", err, "resultFields", resultFields)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/toolkit/commands/call_test.go
+++ b/pkg/toolkit/commands/call_test.go
@@ -1,0 +1,123 @@
+package commands_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ajbouh/substrate/pkg/toolkit/commands"
+	"github.com/ajbouh/substrate/pkg/toolkit/commands/handle"
+	"github.com/ajbouh/substrate/pkg/toolkit/engine"
+	"github.com/ajbouh/substrate/pkg/toolkit/engine/daemon"
+	"github.com/ajbouh/substrate/pkg/toolkit/httpframework"
+	"github.com/ajbouh/substrate/pkg/toolkit/service"
+)
+
+// Run assembles units and starts the program.
+func InitHandler(units ...engine.Unit) http.Handler {
+	asm := Assemble(units...)
+
+	var h []http.Handler
+
+	for i := len(asm.Units()) - 1; i >= 0; i-- {
+		u := asm.Units()[i]
+		r, ok := u.(*httpframework.Framework)
+		if ok {
+			h = append(h, r)
+		}
+	}
+
+	if len(h) != 1 {
+		panic(fmt.Errorf("expected 1 http.Handler, got %d", len(h)))
+	}
+	return h[0]
+}
+
+func Assemble(units ...engine.Unit) *engine.Assembly {
+	asm, err := engine.New(units...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// add assembly
+	if err := asm.Add(asm); err != nil {
+		panic(err)
+	}
+
+	// add daemon framework
+	d := &daemon.Framework{}
+	if err := asm.Add(d); err != nil {
+		panic(err)
+	}
+
+	// // add cli framework
+	// c := &cli.Framework{}
+	// if err := asm.Add(c); err != nil {
+	// 	panic(err)
+	// }
+
+	// add logger
+	if err := asm.Add(slog.Default()); err != nil {
+		panic(err)
+	}
+
+	// re-assemble
+	asm, err = engine.Assemble(asm.Units()...)
+	if err != nil {
+		panic(err)
+	}
+
+	for i := len(asm.Units()) - 1; i >= 0; i-- {
+		u := asm.Units()[i]
+		r, ok := u.(daemon.Initializer)
+		if ok {
+			if err := r.InitializeDaemon(); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	return asm
+}
+
+func TestCallCommand(t *testing.T) {
+	type EchoReturn struct {
+		Output string `json:"output"`
+	}
+	h := InitHandler(
+		&service.Service{},
+		handle.Command("echo", "Echo",
+			func(ctx context.Context,
+				t *struct{},
+				args struct {
+					Input string `json:"input"`
+				}) (EchoReturn, error) {
+				slog.Info("echo", "args", args)
+				return EchoReturn{Output: args.Input}, nil
+			}),
+	)
+
+	client := &struct {
+		Reflector commands.URLReflector
+	}{}
+	Assemble(&service.Service{}, client)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	// XXX using CallURL here, though this should be ported to use cap-based
+	// client such as in bridge/calls
+	// CallURL seems like it's not used, and could probably be removed since
+	// AFAICT that pattern is being deprecated.
+	response, err := commands.CallURL[EchoReturn](context.Background(), client.Reflector, srv.URL, "echo", commands.Fields{
+		"input": "hello world",
+	})
+	if err != nil {
+		t.Fatalf("error calling command: %v", err)
+	}
+	t.Logf("Response: %+v", response)
+}

--- a/pkg/toolkit/commands/call_test.go
+++ b/pkg/toolkit/commands/call_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ajbouh/substrate/pkg/toolkit/commands"
@@ -15,6 +16,7 @@ import (
 	"github.com/ajbouh/substrate/pkg/toolkit/engine/daemon"
 	"github.com/ajbouh/substrate/pkg/toolkit/httpframework"
 	"github.com/ajbouh/substrate/pkg/toolkit/service"
+	"gotest.tools/assert"
 )
 
 // Run assembles units and starts the program.
@@ -97,7 +99,8 @@ func TestCallCommand(t *testing.T) {
 					Input string `json:"input"`
 				}) (EchoReturn, error) {
 				slog.Info("echo", "args", args)
-				return EchoReturn{Output: args.Input}, nil
+				text := strings.ToUpper(args.Input)
+				return EchoReturn{Output: text}, nil
 			}),
 	)
 
@@ -116,4 +119,5 @@ func TestCallCommand(t *testing.T) {
 		t.Fatalf("error calling command: %v", err)
 	}
 	t.Logf("Response: %+v", response)
+	assert.Equal(t, response.Output, "HELLO WORLD")
 }

--- a/pkg/toolkit/commands/call_test.go
+++ b/pkg/toolkit/commands/call_test.go
@@ -102,18 +102,14 @@ func TestCallCommand(t *testing.T) {
 	)
 
 	client := &struct {
-		Reflector commands.URLReflector
+		Env commands.Env
 	}{}
 	Assemble(&service.Service{}, client)
 
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	// XXX using CallURL here, though this should be ported to use cap-based
-	// client such as in bridge/calls
-	// CallURL seems like it's not used, and could probably be removed since
-	// AFAICT that pattern is being deprecated.
-	response, err := commands.CallURL[EchoReturn](context.Background(), client.Reflector, srv.URL, "echo", commands.Fields{
+	response, err := commands.CallURL[EchoReturn](context.Background(), client.Env, srv.URL, "echo", commands.Fields{
 		"input": "hello world",
 	})
 	if err != nil {

--- a/pkg/toolkit/commands/capreflectedmsg.go
+++ b/pkg/toolkit/commands/capreflectedmsg.go
@@ -25,10 +25,49 @@ func (a *CapReflectedMsg) Apply(env Env, m Fields) (Fields, error) {
 		return nil, err
 	}
 
-	parameters, err := Get[Fields](m, "parameters")
+	data, err := GetPath[Fields](m, "data")
 	if err != nil {
 		return nil, err
 	}
+	if true {
+		return env.Apply(nil, Fields{
+			"cap": "seq",
+			"tmp": Fields{
+				"url":  urlStr,
+				"name": name,
+				"data": data,
+			},
+			"ret": Fields{
+				"#": "#/seq/1/par/0",
+			},
+			"seq": Fields{
+				"0": Fields{
+					"pre": Fields{
+						"#/par/0/url":    "#/tmp/url",
+						"#/par/1/path/2": "#/tmp/name",
+					},
+					"var": Fields{
+						"dataptr": "#/tmp/data",
+					},
+					"par": Fields{
+						"0": Fields{"cap": "reflect"},
+						"1": Fields{"cap": "ptr", "path": []any{"tmp", "msgindex", nil}},
+					},
+					"out": Fields{
+						"#/tmp/msgindex":              "#/par/0/msgindex",
+						"#/seq/1/pre/#~1par~10":       "#/par/1/pointer",
+						"#/seq/1/pre/#~1par~10~1data": "#/var/dataptr",
+					},
+				},
+				"1": Fields{
+					"par": Fields{
+						"0": nil,
+					},
+				},
+			},
+		})
+	}
+	parameters := Fields{}
 
 	di, err := ReflectURL(env.Context(), a.Client, urlStr)
 	if err != nil {
@@ -67,4 +106,5 @@ func (a *CapReflectedMsg) Apply(env Env, m Fields) (Fields, error) {
 			"#/returns": "#/msg/returns",
 		},
 	})
+
 }


### PR DESCRIPTION
Adds a simple test harness to set up a Go service that provides a command, and then calls it.
This test fails right now, demonstrating an issue with the command calling in Go.