### PR TITLE
WIP quickjs: use commands.CallURL

### DIFF
--- a/images/quickjs/units/eval.go
+++ b/images/quickjs/units/eval.go
@@ -25,7 +25,7 @@ type QuickJSInit struct {
 var AddReflectorAsGlobal = notify.On(func(ctx context.Context,
 	qctx *quickjs.Context,
 	t *struct {
-		Reflector commands.URLReflector
+		Env commands.Env
 	}) {
 	slog.Info("AddReflectorAsGlobal", "t", t)
 
@@ -38,7 +38,11 @@ var AddReflectorAsGlobal = notify.On(func(ctx context.Context,
 			url = os.Getenv("INTERNAL_SUBSTRATE_ORIGIN") + url
 
 		}
-		return commands.RunURL(context.Background(), t.Reflector, url, command, parameters)
+		out, err := commands.CallURL[commands.Fields](context.Background(), t.Env, url, command, parameters)
+		if err != nil {
+			return nil, err
+		}
+		return *out, nil
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
RunURL doesn't seem to work anymore, params are dropped from the request.
This is still not fully working, but I think part of the necessary change.

With this change, I tried testing transcription, but am getting a new error listed below.

```
$ go url: "/quickjs"

. eval source: `reflector.run(
  "http://substrate:8080/substrate/v1/msgindex",
  "faster-whisper/transcribe-url",
  {
    task: "transcribe",
    audio_url: "http://substrate:8080/not-needed-here",
    audio_metadata: {mime_type: "audio/wav"}
  }
);
`
```

```
2025/04/29 22:12:28 INFO command run() done command=eval parameters="map[arguments:[map[cfg:map[command:faster-whisper/transcribe-url command_url:http://substrate:8080/substrate/v1/msgindex dest_path:/foobar/transcription/segmented stream_url_prefix:https://substrate:8080/webrtc-stream;event_prefix=foobar;sessions=sp-01JRXDBH70GP1DD6SFK7YV2VKH/audio/wav/] events:[map[at:01JSQGNP0NTBGFC3V3ZHV5RQ6M fields:map[end:9.37193292e+08 path:/foobar/tracks/01JSQGNDDM2ZVV7D6VAX62NHAV/activity start:9.37149132e+08] fields_sha256:f4fd9850861eeb1aaa65f361298679dd2167a038c42875c1468315d508b79ef4 fields_size:95 id:01JSQGNP0NTBGFC3V3ZHV5RQ6M since:01JSQGNND0B9X29Q1F66D67ZPH]]]]
source:\n                function x({ events, cfg: {command_url, command, stream_url_prefix, dest_path} }) {...]" returns=map[]
err="Error: error applying capability! reflectedmsg: error applying capability! seq: no value for []string{\"cap\"} in commands.Fields{\"data\":map[string]interface {}{\"parameters\":map[string]interface {}{\"audio_metadata\":map[string]interface {}{\"mime_type\":\"audio/wav\"}, \"audio_url\":\"https://substrate:8080/webrtc-stream;event_prefix=foobar;sessions=sp-01JRXDBH70GP1DD6SFK7YV2VKH/audio/wav/undefined?%7B%22segments%22%3A%5B%7B%22start%22%3A937149132%2C%22end%22%3A937193292%7D%5D%7D\", \"task\":\"transcribe\"}}}”
```